### PR TITLE
feat(hash_join): implement basic Inner/Left/Right/Full Join operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ async-channel = "1.8.0"
 async-backtrace = "0.2.6"
 futures = "0.3.25"
 futures-lite = "1.12.0"
+ahash = "0.8.3"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -4,7 +4,7 @@ pub mod expr;
 mod select;
 mod insert;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use anyhow::Result;
 use sqlparser::ast::{Ident, ObjectName, SetExpr, Statement};
@@ -16,8 +16,8 @@ use crate::types::TableIdx;
 #[derive(Clone)]
 pub struct BinderContext {
     catalog: RootCatalog,
-    bind_table: HashMap<String, TableIdx>,
-    aliases: HashMap<String, ScalarExpression>,
+    bind_table: BTreeMap<String, TableIdx>,
+    aliases: BTreeMap<String, ScalarExpression>,
     group_by_exprs: Vec<ScalarExpression>,
     agg_calls: Vec<ScalarExpression>,
     index: u16,

--- a/src/db.rs
+++ b/src/db.rs
@@ -150,10 +150,11 @@ mod test {
 
         tokio_test::block_on(async move {
             let _ = kipsql.run("create table t1 (a int, b int)").await?;
-            let _ = kipsql.run("insert into t1 values (1, 1), (2, 3), (5, 4)").await?;
+            let _ = kipsql.run("create table t2 (c int, d int)").await?;
+            let _ = kipsql.run("insert into t1 values (1, 1), (3, 3), (5, 4)").await?;
+            let _ = kipsql.run("insert into t2 values (1, 2), (2, 3), (5, 6)").await?;
 
-            println!("full:");
-            let vec_batch_full_fields = kipsql.run("select * from t1").await?;
+            let vec_batch_full_fields = kipsql.run("select * from t1 right join t2 on a = c").await?;
             print_batches(&vec_batch_full_fields)?;
 
             println!("projection_and_filter:");
@@ -167,6 +168,22 @@ mod test {
             println!("limit:");
             let vec_batch_limit=kipsql.run("select * from t1 limit 1 offset 1").await?;
             print_batches(&vec_batch_limit)?;
+
+            println!("inner join:");
+            let vec_batch_inner_join = kipsql.run("select * from t1 inner join t2 on a = c").await?;
+            print_batches(&vec_batch_inner_join)?;
+
+            println!("left join:");
+            let vec_batch_left_join = kipsql.run("select * from t1 left join t2 on a = c").await?;
+            print_batches(&vec_batch_left_join)?;
+
+            println!("right join:");
+            let vec_batch_right_join = kipsql.run("select * from t1 right join t2 on a = c").await?;
+            print_batches(&vec_batch_right_join)?;
+
+            println!("full join:");
+            let vec_batch_full_join = kipsql.run("select * from t1 full join t2 on a = c").await?;
+            print_batches(&vec_batch_full_join)?;
 
             Ok(())
         })

--- a/src/execution_v1/physical_plan/mod.rs
+++ b/src/execution_v1/physical_plan/mod.rs
@@ -1,5 +1,6 @@
 use crate::execution_v1::physical_plan::physical_create_table::PhysicalCreateTable;
 use crate::execution_v1::physical_plan::physical_filter::PhysicalFilter;
+use crate::execution_v1::physical_plan::physical_hash_join::PhysicalHashJoin;
 use crate::execution_v1::physical_plan::physical_insert::PhysicalInsert;
 use crate::execution_v1::physical_plan::physical_limit::PhysicalLimit;
 use crate::execution_v1::physical_plan::physical_projection::PhysicalProjection;
@@ -16,6 +17,7 @@ pub(crate) mod physical_values;
 pub(crate) mod physical_filter;
 pub(crate) mod physical_sort;
 pub(crate) mod physical_limit;
+pub(crate) mod physical_hash_join;
 
 #[derive(Debug)]
 pub enum PhysicalPlan {
@@ -27,4 +29,5 @@ pub enum PhysicalPlan {
     Sort(PhysicalSort),
     Values(PhysicalValues),
     Limit(PhysicalLimit),
+    HashJoin(PhysicalHashJoin),
 }

--- a/src/execution_v1/physical_plan/physical_hash_join.rs
+++ b/src/execution_v1/physical_plan/physical_hash_join.rs
@@ -1,0 +1,9 @@
+use crate::execution_v1::physical_plan::PhysicalPlan;
+use crate::planner::operator::join::JoinOperator;
+
+#[derive(Debug)]
+pub struct PhysicalHashJoin {
+    pub(crate) op: JoinOperator,
+    pub(crate) left_input: Box<PhysicalPlan>,
+    pub(crate) right_input: Box<PhysicalPlan>
+}

--- a/src/execution_v1/volcano_executor/hash_join.rs
+++ b/src/execution_v1/volcano_executor/hash_join.rs
@@ -1,0 +1,238 @@
+use std::collections::BTreeSet;
+use std::mem;
+use std::sync::Arc;
+use ahash::{HashMap, HashMapExt, RandomState};
+use arrow::array::{ArrayRef, BooleanArray, new_null_array, PrimitiveArray, UInt32Builder};
+use arrow::compute;
+use arrow::datatypes::{Field, Schema, UInt32Type};
+use arrow::record_batch::RecordBatch;
+use futures_async_stream::try_stream;
+use itertools::Itertools;
+use crate::execution_v1::ExecutorError;
+use crate::execution_v1::volcano_executor::BoxedExecutor;
+use crate::expression::ScalarExpression;
+use crate::planner::operator::join::{JoinCondition, JoinType};
+use crate::util::hash_utils::create_hashes;
+
+pub struct HashJoin { }
+
+impl HashJoin {
+    #[try_stream(boxed, ok = RecordBatch, error = ExecutorError)]
+    pub async fn execute(on: JoinCondition, ty: JoinType, left_input: BoxedExecutor, right_input: BoxedExecutor) {
+        if ty == JoinType::Cross {
+            unreachable!("Cross join should not be in HashJoinExecutor");
+        }
+        let ((on_left_keys, on_right_keys), filter) = match on {
+            JoinCondition::On { on, filter } => (on.into_iter().unzip(), filter),
+            JoinCondition::None => unreachable!("HashJoin must has on condition")
+        };
+
+        // build phase:
+        // 1.construct hashtable, one hash key may contains multiple rows indices.
+        // 2.merged all left batches into single batch.
+        let mut left_hashmap = HashMap::new();
+        let mut left_row_offset = 0;
+        let mut left_batches = vec![];
+
+        let hash_random_state = RandomState::with_seeds(0, 0, 0, 0);
+        let mut join_fields: Vec<Field> = Vec::new();
+        // FIXME: 应该在Binder层处理，使Project能够同时获取此nullable信息(因为Join会改变主键的nullable判定)
+        let (left_force_nullable, right_force_nullable) = match ty {
+            JoinType::Inner => (false, false),
+            JoinType::Left => (false, true),
+            JoinType::Right => (true, false),
+            JoinType::Full => (true, true),
+            JoinType::Cross => (true, true),
+        };
+
+        #[for_await]
+        for batch in left_input {
+            let batch: RecordBatch = batch?;
+            let rows_hashes = Self::hash_columns(&on_left_keys, &hash_random_state, &batch)?;
+
+            if join_fields.is_empty() {
+                Self::filling_fields(&mut join_fields, left_force_nullable, &batch);
+            }
+
+            for (row, hash) in rows_hashes.iter().enumerate() {
+                left_hashmap
+                    .entry(*hash)
+                    .or_insert_with(Vec::new)
+                    .push(row + left_row_offset);
+            }
+
+            left_row_offset += batch.num_rows();
+            left_batches.push(batch);
+        }
+
+        let left_single_batch = if left_batches.is_empty() && (ty == JoinType::Left || ty == JoinType::Inner) {
+            None
+        } else {
+            Some(compute::concat_batches(&left_batches[0].schema(), &left_batches)?)
+        };
+
+        // probe phase
+        //
+        // build visited_left_side to record the left data has been visited,
+        // because probe phase only visit the right data, so if we use left-join or full-join,
+        // the left unvisited data should be returned to meet the join semantics.
+        let full_left_side: BTreeSet<u32> = (0..left_row_offset as u32)
+            .into_iter()
+            .collect();
+        let mut visited_left_side = BTreeSet::new();
+        let mut join_schema = None;
+
+        #[for_await]
+        for batch in right_input {
+            let batch = batch?;
+            let rows_hashes = Self::hash_columns(&on_right_keys, &hash_random_state, &batch)?;
+
+            // init join_schema
+            let schema = join_schema.get_or_insert_with(|| {
+                Self::filling_fields(&mut join_fields, right_force_nullable, &batch);
+
+                Arc::new(Schema::new(mem::take(&mut join_fields)))
+            });
+
+            // 1. build left and right indices
+            let mut left_indices = UInt32Builder::new();
+            let mut right_indices = UInt32Builder::new();
+            // for sqlrs: Get the hash and find it in the build index
+            // TODO: For every item on the left and right we check if it matches
+            // This possibly contains rows with hash collisions,
+            // So we have to check here whether rows are equal or not
+            for (row, hash) in rows_hashes.iter().enumerate() {
+                if let Some(indices) = left_hashmap.get(hash) {
+                    for &i in indices {
+                        left_indices.append_value(i as u32);
+                        right_indices.append_value(row as u32);
+                    }
+                } else if ty == JoinType::Right || ty == JoinType::Full {
+                    // when no match, add the row with None for the left side
+                    left_indices.append_null();
+                    right_indices.append_value(row as u32);
+                }
+            }
+
+            // 2. build intermediate batch that from left and right all columns
+            let mut left_indices = left_indices.finish();
+            let mut  right_indices = right_indices.finish();
+
+            let mut intermediate_batch = Self::build_batch(
+                &left_single_batch,
+                &batch,
+                schema,
+                &left_indices,
+                &right_indices
+            )?;
+
+            if let Some(ref expr) = filter {
+                let predicate = expr.eval_column(&intermediate_batch)?
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .cloned()
+                    .expect("join filter expected evaluate boolean array");
+                left_indices = PrimitiveArray::<UInt32Type>::from(
+                    compute::filter(&left_indices, &predicate)?.data().clone(),
+                );
+                if ty == JoinType::Right || ty == JoinType::Full {
+                    right_indices = PrimitiveArray::<UInt32Type>::from(
+                        compute::filter(&right_indices, &predicate)?.data().clone(),
+                    )
+                };
+
+                intermediate_batch = Self::build_batch(
+                    &left_single_batch,
+                    &batch,
+                    schema,
+                    &left_indices,
+                    &right_indices
+                )?;
+            }
+
+            if ty == JoinType::Left || ty == JoinType::Full {
+                left_indices
+                    .iter()
+                    .flatten()
+                    .for_each(|i| {
+                        let _ = visited_left_side.insert(i);
+                    });
+            }
+            yield intermediate_batch;
+        }
+
+        if let Some(left_batch) = left_single_batch {
+            if ty == JoinType::Left || ty == JoinType::Full {
+                let join_schema = join_schema.unwrap();
+
+                let indices: PrimitiveArray<UInt32Type> = PrimitiveArray::from_iter_values(
+                    full_left_side
+                        .symmetric_difference(&visited_left_side)
+                        .cloned()
+                );
+
+                let mut arrays: Vec<ArrayRef> = left_batch
+                    .columns()
+                    .iter()
+                    .map(|col| compute::take(col, &indices, None))
+                    .try_collect()?;
+                let offset = arrays.len();
+                for field in join_schema.fields()[offset..].iter() {
+                    arrays.push(new_null_array(field.data_type(), indices.len()));
+                }
+
+                yield RecordBatch::try_new(join_schema, arrays)?;
+            }
+        }
+    }
+
+    fn filling_fields(join_fields: &mut Vec<Field>, force_nullable: bool, batch: &RecordBatch) {
+        let mut fields = batch.schema().fields()
+            .into_iter()
+            .map(|field| field.clone().with_nullable(force_nullable))
+            .collect_vec();
+
+        join_fields.append(&mut fields);
+    }
+
+    fn build_batch(
+        left_single_batch: &Option<RecordBatch>,
+        right_batch: &RecordBatch,
+        schema: &mut Arc<Schema>,
+        left_indices: &PrimitiveArray<UInt32Type>,
+        right_indices: &PrimitiveArray<UInt32Type>
+    ) -> Result<RecordBatch, ExecutorError> {
+        let full_arrays = if let Some(left_batch) = left_single_batch {
+            Self::select_with_indices(left_batch, &left_indices)?
+        } else {
+            vec![]
+        }.into_iter()
+            .chain(Self::select_with_indices(right_batch, &right_indices)?)
+            .collect_vec();
+        Ok(RecordBatch::try_new(schema.clone(), full_arrays)?)
+    }
+
+    fn select_with_indices(batch: &RecordBatch, indices: &PrimitiveArray<UInt32Type>) -> Result<Vec<ArrayRef>, ExecutorError> {
+        Ok(batch
+            .columns()
+            .iter()
+            .map(|col| compute::take(col, &indices, None))
+            .try_collect()?)
+    }
+
+    fn hash_columns(
+        col_keys: &Vec<ScalarExpression>,
+        hash_random_state: &RandomState,
+        batch: &RecordBatch
+    ) -> Result<Vec<u64>, ExecutorError> {
+        let arrays: Vec<ArrayRef> = col_keys
+            .iter()
+            .map(|expr| expr.eval_column(&batch))
+            .try_collect()?;
+
+        let mut every_rows_hashes = vec![0; batch.num_rows()];
+        create_hashes(&arrays, &hash_random_state, &mut every_rows_hashes)?;
+
+        Ok(every_rows_hashes)
+    }
+}

--- a/src/execution_v1/volcano_executor/insert.rs
+++ b/src/execution_v1/volcano_executor/insert.rs
@@ -23,6 +23,8 @@ impl Insert {
                 let mut arrays = batch.columns().to_vec();
                 let col_len = arrays[0].len();
 
+                arrays.reverse();
+
                 let full_arrays = table.all_columns()
                     .into_iter()
                     .map(|(_, col_catalog)| {

--- a/src/execution_v1/volcano_executor/projection.rs
+++ b/src/execution_v1/volcano_executor/projection.rs
@@ -10,19 +10,24 @@ pub struct Projection { }
 impl Projection {
     #[try_stream(boxed, ok = RecordBatch, error = ExecutorError)]
     pub async fn execute(exprs: Vec<ScalarExpression>, input: BoxedExecutor) {
+        // FIXME: 支持JOIN投射
+        // #[for_await]
+        // for batch in input {
+        //     let batch = batch?;
+        //     let columns = exprs
+        //         .iter()
+        //         .map(|e| e.eval_column(&batch))
+        //         .try_collect();
+        //     let fields = exprs.iter().map(|e| e.eval_field(&batch)).collect();
+        //     let schema = SchemaRef::new(Schema::new_with_metadata(
+        //         fields,
+        //         batch.schema().metadata().clone(),
+        //     ));
+        //     yield RecordBatch::try_new(schema, columns?)?;
+        // }
         #[for_await]
         for batch in input {
-            let batch = batch?;
-            let columns = exprs
-                .iter()
-                .map(|e| e.eval_column(&batch))
-                .try_collect();
-            let fields = exprs.iter().map(|e| e.eval_field(&batch)).collect();
-            let schema = SchemaRef::new(Schema::new_with_metadata(
-                fields,
-                batch.schema().metadata().clone(),
-            ));
-            yield RecordBatch::try_new(schema, columns?)?;
+            yield batch?;
         }
     }
 }

--- a/src/planner/operator/join.rs
+++ b/src/planner/operator/join.rs
@@ -6,19 +6,25 @@ use super::Operator;
 #[derive(Debug, PartialEq, Clone)]
 pub enum JoinType {
     Inner,
-    LeftOuter,
-    RightOuter,
-    FullOuter,
+    Left,
+    Right,
+    Full,
     Cross,
-    LeftSemi,
-    RightSemi,
-    LeftAnti,
-    RightAnti,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub enum JoinCondition {
+    On {
+        /// Equijoin clause expressed as pairs of (left, right) join columns
+        on: Vec<(ScalarExpression, ScalarExpression)>,
+        /// Filters applied during join (non-equi conditions)
+        filter: Option<ScalarExpression>,
+    },
+    None,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct JoinOperator {
-    pub on: Option<ScalarExpression>,
+    pub on: JoinCondition,
     pub join_type: JoinType,
 }
 
@@ -26,7 +32,7 @@ impl JoinOperator {
     pub fn new(
         left: LogicalPlan,
         right: LogicalPlan,
-        on: Option<ScalarExpression>,
+        on: JoinCondition,
         join_type: JoinType,
     ) -> LogicalPlan {
         LogicalPlan {

--- a/src/util/hash_utils.rs
+++ b/src/util/hash_utils.rs
@@ -1,0 +1,250 @@
+// copied from datafusion and deleted unused functions
+
+use ahash::RandomState;
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray,
+};
+use arrow::datatypes::DataType;
+
+use crate::execution_v1::ExecutorError;
+
+// Combines two hashes into one hash
+#[inline]
+fn combine_hashes(l: u64, r: u64) -> u64 {
+    let hash = (17 * 37u64).wrapping_add(l);
+    hash.wrapping_mul(37).wrapping_add(r)
+}
+
+fn hash_null(random_state: &RandomState, hashes_buffer: &'_ mut [u64], mul_col: bool) {
+    if mul_col {
+        hashes_buffer.iter_mut().for_each(|hash| {
+            // stable hash for null value
+            *hash = combine_hashes(random_state.hash_one(&1), *hash);
+        })
+    } else {
+        hashes_buffer.iter_mut().for_each(|hash| {
+            *hash = random_state.hash_one(&1);
+        })
+    }
+}
+
+macro_rules! hash_array {
+    (
+        $array_type:ident,
+        $column:ident,
+        $ty:ty,
+        $hashes:ident,
+        $random_state:ident,
+        $multi_col:ident
+    ) => {
+        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
+        if array.null_count() == 0 {
+            if $multi_col {
+                for (i, hash) in $hashes.iter_mut().enumerate() {
+                    *hash = combine_hashes($random_state.hash_one(&array.value(i)), *hash);
+                }
+            } else {
+                for (i, hash) in $hashes.iter_mut().enumerate() {
+                    *hash = $random_state.hash_one(&array.value(i));
+                }
+            }
+        } else {
+            if $multi_col {
+                for (i, hash) in $hashes.iter_mut().enumerate() {
+                    if !array.is_null(i) {
+                        *hash = combine_hashes($random_state.hash_one(&array.value(i)), *hash);
+                    }
+                }
+            } else {
+                for (i, hash) in $hashes.iter_mut().enumerate() {
+                    if !array.is_null(i) {
+                        *hash = $random_state.hash_one(&array.value(i));
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! hash_array_primitive {
+    (
+        $array_type:ident,
+        $column:ident,
+        $ty:ident,
+        $hashes:ident,
+        $random_state:ident,
+        $multi_col:ident
+    ) => {
+        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
+        let values = array.values();
+
+        if array.null_count() == 0 {
+            if $multi_col {
+                for (hash, value) in $hashes.iter_mut().zip(values.iter()) {
+                    *hash = combine_hashes($random_state.hash_one(value), *hash);
+                }
+            } else {
+                for (hash, value) in $hashes.iter_mut().zip(values.iter()) {
+                    *hash = $random_state.hash_one(value)
+                }
+            }
+        } else {
+            if $multi_col {
+                for (i, (hash, value)) in $hashes.iter_mut().zip(values.iter()).enumerate() {
+                    if !array.is_null(i) {
+                        *hash = combine_hashes($random_state.hash_one(value), *hash);
+                    }
+                }
+            } else {
+                for (i, (hash, value)) in $hashes.iter_mut().zip(values.iter()).enumerate() {
+                    if !array.is_null(i) {
+                        *hash = $random_state.hash_one(value);
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! hash_array_float {
+    (
+        $array_type:ident,
+        $column:ident,
+        $ty:ident,
+        $hashes:ident,
+        $random_state:ident,
+        $multi_col:ident
+    ) => {
+        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
+        let values = array.values();
+
+        if array.null_count() == 0 {
+            if $multi_col {
+                for (hash, value) in $hashes.iter_mut().zip(values.iter()) {
+                    *hash = combine_hashes(
+                        $random_state.hash_one(&$ty::from_le_bytes(value.to_le_bytes())),
+                        *hash,
+                    );
+                }
+            } else {
+                for (hash, value) in $hashes.iter_mut().zip(values.iter()) {
+                    *hash = $random_state.hash_one(&$ty::from_le_bytes(value.to_le_bytes()))
+                }
+            }
+        } else {
+            if $multi_col {
+                for (i, (hash, value)) in $hashes.iter_mut().zip(values.iter()).enumerate() {
+                    if !array.is_null(i) {
+                        *hash = combine_hashes(
+                            $random_state.hash_one(&$ty::from_le_bytes(value.to_le_bytes())),
+                            *hash,
+                        );
+                    }
+                }
+            } else {
+                for (i, (hash, value)) in $hashes.iter_mut().zip(values.iter()).enumerate() {
+                    if !array.is_null(i) {
+                        *hash = $random_state.hash_one(&$ty::from_le_bytes(value.to_le_bytes()));
+                    }
+                }
+            }
+        }
+    };
+}
+
+/// Creates hash values for every row, based on the values in the
+/// columns.
+///
+/// The number of rows to hash is determined by `hashes_buffer.len()`.
+/// `hashes_buffer` should be pre-sized appropriately
+#[cfg(not(feature = "force_hash_collisions"))]
+pub fn create_hashes<'a>(
+    arrays: &[ArrayRef],
+    random_state: &RandomState,
+    hashes_buffer: &'a mut Vec<u64>,
+) -> Result<&'a mut Vec<u64>, ExecutorError> {
+    // combine hashes with `combine_hashes` if we have more than 1 column
+    let multi_col = arrays.len() > 1;
+
+    for col in arrays {
+        match col.data_type() {
+            DataType::Null => {
+                hash_null(random_state, hashes_buffer, multi_col);
+            }
+            DataType::Int32 => {
+                hash_array_primitive!(Int32Array, col, i32, hashes_buffer, random_state, multi_col);
+            }
+            DataType::Int64 => {
+                hash_array_primitive!(Int64Array, col, i64, hashes_buffer, random_state, multi_col);
+            }
+            DataType::Float64 => {
+                hash_array_float!(
+                    Float64Array,
+                    col,
+                    u64,
+                    hashes_buffer,
+                    random_state,
+                    multi_col
+                );
+            }
+            DataType::Boolean => {
+                hash_array!(
+                    BooleanArray,
+                    col,
+                    u8,
+                    hashes_buffer,
+                    random_state,
+                    multi_col
+                );
+            }
+            DataType::Utf8 => {
+                hash_array!(
+                    StringArray,
+                    col,
+                    str,
+                    hashes_buffer,
+                    random_state,
+                    multi_col
+                );
+            }
+            _ => {
+                // This is internal because we should have caught this before.
+                return Err(ExecutorError::InternalError(format!(
+                    "Unsupported data type in hasher: {}",
+                    col.data_type()
+                )));
+            }
+        }
+    }
+    Ok(hashes_buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn create_hashes_for_float_arrays() -> Result<(), ExecutorError> {
+        let f64_arr = Arc::new(Float64Array::from_iter_values(vec![0.12, 0.5, 1f64, 444.7]));
+        let f64_arr_2 = Arc::new(Float64Array::from_iter_values(vec![0.12, 0.5, 1f64, 444.7]));
+
+        let random_state = RandomState::with_seeds(0, 0, 0, 0);
+        let hashes_buff = &mut vec![0; f64_arr.len()];
+
+        let hashes = create_hashes(&[f64_arr, f64_arr_2], &random_state, hashes_buff)?;
+        assert_eq!(hashes.len(), 4);
+        assert_eq!(hashes.clone(), hashes_buff.clone());
+        assert_eq!(
+            hashes_buff,
+            &[
+                13192744372685867462,
+                5527281222425499956,
+                3851526787237496334,
+                1092489821776418240,
+            ]
+        );
+        Ok(())
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,7 @@
+pub mod hash_utils;
 
 use arrow::record_batch::RecordBatch;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
 use arrow::util::display::array_value_to_string;
 


### PR DESCRIPTION
found a problem that needs to be fixed:
- when the `Projection` operator executes eval_column, the reading data is abnormal due to the duplication of the ColumnIdx subscript of the Catalog So `Binder::bind_project` need to support join

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [ ] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
