### PR TITLE
feat: Refactor 'DataValue' length check logic; add support for varchar computations

### DIFF
--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -78,7 +78,7 @@ mod tests {
                 assert_eq!(op.columns[0].desc, ColumnDesc::new(LogicalType::Integer, true));
                 assert_eq!(op.columns[1].name, "name".to_string());
                 assert_eq!(op.columns[1].nullable, true);
-                assert_eq!(op.columns[1].desc, ColumnDesc::new(LogicalType::Varchar, false));
+                assert_eq!(op.columns[1].desc, ColumnDesc::new(LogicalType::Varchar(Some(10)), false));
             }
             _ => unreachable!()
         }

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -52,6 +52,11 @@ impl<S: Storage> Binder<S> {
                             let cast_value = DataValue::clone(value)
                                 .cast(columns[i].datatype())?;
 
+                            // Check if the value length is too long
+                            if Some(cast_value.to_raw().len()) > columns[i].datatype().raw_len() {
+                                return Err(BindError::InvalidTable(format!("value length is too long")))
+                            }
+
                             row.push(Arc::new(cast_value))
                         },
                         ScalarExpression::Unary { expr, op, .. } => {

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -49,14 +49,10 @@ impl<S: Storage> Binder<S> {
                 for (i, expr) in expr_row.into_iter().enumerate() {
                     match &self.bind_expr(expr).await? {
                         ScalarExpression::Constant(value) => {
+                            // Check if the value length is too long
+                            value.check_length(columns[i].datatype())?;
                             let cast_value = DataValue::clone(value)
                                 .cast(columns[i].datatype())?;
-
-                            // Check if the value length is too long
-                            if Some(cast_value.to_raw().len()) > columns[i].datatype().raw_len() {
-                                return Err(BindError::InvalidTable(format!("value length is too long")))
-                            }
-
                             row.push(Arc::new(cast_value))
                         },
                         ScalarExpression::Unary { expr, op, .. } => {

--- a/src/binder/update.rs
+++ b/src/binder/update.rs
@@ -44,6 +44,7 @@ impl<S: Storage> Binder<S> {
                         bind_table_name.as_ref()
                     ).await? {
                         ScalarExpression::ColumnRef(catalog) => {
+                            value.check_length(catalog.datatype())?;
                             columns.push(catalog);
                             row.push(value.clone());
                         },

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -12,6 +12,8 @@ pub enum TypeError {
     InternalError(String),
     #[error("cast fail")]
     CastFail,
+    #[error("Too long")]
+    TooLong,
     #[error("cannot be Null")]
     NotNull,
     #[error("try from int")]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -133,7 +133,7 @@ mod tests {
             Arc::new(ColumnCatalog::new(
                 "c3".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Varchar, false)
+                ColumnDesc::new(LogicalType::Varchar(None), false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c4".to_string(),

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -35,9 +35,11 @@ impl Tuple {
             if bit_index(bytes[i / BITS_MAX_INDEX], i % BITS_MAX_INDEX) {
                 values.push(Arc::new(DataValue::none(logic_type)));
             } else if let Some(len) = logic_type.raw_len() {
+                /// fixed length (e.g.: int)
                 values.push(Arc::new(DataValue::from_raw(&bytes[pos..pos + len], logic_type)));
                 pos += len;
             } else {
+                /// variable length (e.g.: varchar)
                 let len = u32::decode_fixed(&bytes[pos..pos + 4]) as usize;
                 pos += 4;
                 values.push(Arc::new(DataValue::from_raw(&bytes[pos..pos + len], logic_type)));
@@ -133,7 +135,7 @@ mod tests {
             Arc::new(ColumnCatalog::new(
                 "c3".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Varchar(None), false)
+                ColumnDesc::new(LogicalType::Varchar(Some(2)), false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c4".to_string(),

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -183,15 +183,12 @@ macro_rules! varchar_cast {
         $value.map(|v| {
             let string_value = format!("{}", v);
             if let Some(len) = $len {
-                let len_usize = *len as usize;
-                if string_value.len() > len_usize {
-                    Err(TypeError::CastFail)
-                } else {
-                    Ok(DataValue::Utf8(Some(string_value)))
+                if string_value.len() > *len as usize {
+                    return Err(TypeError::TooLong);
                 }
-            } else {
-                Ok(DataValue::Utf8(Some(string_value)))
             }
+            Ok(DataValue::Utf8(Some(string_value)))
+
         }).unwrap_or(Ok(DataValue::Utf8(None)))
     };
 }
@@ -216,12 +213,12 @@ impl DataValue {
                 if let LogicalType::Varchar(len) = logic_type {
                     if let Some(len) = len {
                         if value.as_ref().map(|v| v.len() > *len as usize).unwrap_or(false) {
-                            return Err(TypeError::CastFail);
+                            return Err(TypeError::TooLong);
                         }
                     }
                 }
             }
-            _ => { return Err(TypeError::CastFail); }
+            _ => { return Err(TypeError::InvalidType); }
         }
         Ok(())
     }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -222,7 +222,8 @@ impl DataValue {
             LogicalType::UBigint => DataValue::UInt64(None),
             LogicalType::Float => DataValue::Float32(None),
             LogicalType::Double => DataValue::Float64(None),
-            LogicalType::Varchar => DataValue::Utf8(None),
+            LogicalType::Varchar(_) => DataValue::Utf8(None),
+            LogicalType::Nvarchar(_) => DataValue::Utf8(None),
             LogicalType::Date => DataValue::Date32(None),
             LogicalType::DateTime => DataValue::Date64(None)
         }
@@ -243,7 +244,8 @@ impl DataValue {
             LogicalType::UBigint => DataValue::UInt64(Some(0)),
             LogicalType::Float => DataValue::Float32(Some(0.0)),
             LogicalType::Double => DataValue::Float64(Some(0.0)),
-            LogicalType::Varchar => DataValue::Utf8(Some("".to_string())),
+            LogicalType::Varchar(_) => DataValue::Utf8(Some("".to_string())),
+            LogicalType::Nvarchar(_) => DataValue::Utf8(Some("".to_string())),
             LogicalType::Date => DataValue::Date32(Some(UNIX_DATETIME.num_days_from_ce())),
             LogicalType::DateTime => DataValue::Date64(Some(UNIX_DATETIME.timestamp()))
         }
@@ -292,7 +294,8 @@ impl DataValue {
                 buf.copy_from_slice(bytes);
                 f64::from_ne_bytes(buf)
             })),
-            LogicalType::Varchar => DataValue::Utf8((!bytes.is_empty()).then(|| String::from_utf8(bytes.to_owned()).unwrap())),
+            LogicalType::Varchar(_) => DataValue::Utf8((!bytes.is_empty()).then(|| String::from_utf8(bytes.to_owned()).unwrap())),
+            LogicalType::Nvarchar(_) => DataValue::Utf8((!bytes.is_empty()).then(|| String::from_utf8(bytes.to_owned()).unwrap())),
             LogicalType::Date => DataValue::Date32((!bytes.is_empty()).then(|| i32::decode_fixed(bytes))),
             LogicalType::DateTime => DataValue::Date64((!bytes.is_empty()).then(|| i64::decode_fixed(bytes))),
         }
@@ -312,7 +315,7 @@ impl DataValue {
             DataValue::UInt16(_) => LogicalType::USmallint,
             DataValue::UInt32(_) => LogicalType::UInteger,
             DataValue::UInt64(_) => LogicalType::UBigint,
-            DataValue::Utf8(_) => LogicalType::Varchar,
+            DataValue::Utf8(_) => LogicalType::Varchar(Some(255)),
             DataValue::Date32(_) => LogicalType::Date,
             DataValue::Date64(_) => LogicalType::DateTime,
         }
@@ -350,7 +353,8 @@ impl DataValue {
                     LogicalType::UBigint => Ok(DataValue::UInt64(None)),
                     LogicalType::Float => Ok(DataValue::Float32(None)),
                     LogicalType::Double => Ok(DataValue::Float64(None)),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(None)),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(None)),
+                    LogicalType::Nvarchar(_) => Ok(DataValue::Utf8(None)),
                     LogicalType::Date => Ok(DataValue::Date32(None)),
                     LogicalType::DateTime => Ok(DataValue::Date64(None)),
                 }
@@ -369,7 +373,8 @@ impl DataValue {
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| v.into()))),
                     LogicalType::Float => Ok(DataValue::Float32(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Nvarchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -378,7 +383,7 @@ impl DataValue {
                     LogicalType::SqlNull => Ok(DataValue::Null),
                     LogicalType::Float => Ok(DataValue::Float32(value)),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -386,7 +391,7 @@ impl DataValue {
                 match to {
                     LogicalType::SqlNull => Ok(DataValue::Null),
                     LogicalType::Double => Ok(DataValue::Float64(value)),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -403,7 +408,7 @@ impl DataValue {
                     LogicalType::Bigint => Ok(DataValue::Int64(value.map(|v| v.into()))),
                     LogicalType::Float => Ok(DataValue::Float32(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -419,7 +424,7 @@ impl DataValue {
                     LogicalType::Bigint => Ok(DataValue::Int64(value.map(|v| v.into()))),
                     LogicalType::Float => Ok(DataValue::Float32(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -433,7 +438,7 @@ impl DataValue {
                     LogicalType::Integer => Ok(DataValue::Int32(value.map(|v| v.into()))),
                     LogicalType::Bigint => Ok(DataValue::Int64(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -445,7 +450,7 @@ impl DataValue {
                     LogicalType::UInteger => Ok(DataValue::UInt32(value.map(|v| u32::try_from(v)).transpose()?)),
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| u64::try_from(v)).transpose()?)),
                     LogicalType::Bigint => Ok(DataValue::Int64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -461,7 +466,7 @@ impl DataValue {
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| v.into()))),
                     LogicalType::Float => Ok(DataValue::Float32(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -475,7 +480,7 @@ impl DataValue {
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| v.into()))),
                     LogicalType::Float => Ok(DataValue::Float32(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -486,7 +491,7 @@ impl DataValue {
                     LogicalType::Bigint => Ok(DataValue::Int64(value.map(|v| v.into()))),
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| v.into()))),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -494,7 +499,7 @@ impl DataValue {
                 match to {
                     LogicalType::SqlNull => Ok(DataValue::Null),
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| v.into()))),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.map(|v| format!("{}", v)))),
                     _ => Err(TypeError::CastFail),
                 }
             }
@@ -513,7 +518,8 @@ impl DataValue {
                     LogicalType::UBigint => Ok(DataValue::UInt64(value.map(|v| u64::from_str(&v)).transpose()?)),
                     LogicalType::Float => Ok(DataValue::Float32(value.map(|v| f32::from_str(&v)).transpose()?)),
                     LogicalType::Double => Ok(DataValue::Float64(value.map(|v| f64::from_str(&v)).transpose()?)),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value)),
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value)),
+                    LogicalType::Nvarchar(_) => Ok(DataValue::Utf8(value)),
                     LogicalType::Date => {
                         let option = value.map(|v| {
                             NaiveDate::parse_from_str(&v, DATE_FMT)
@@ -539,7 +545,7 @@ impl DataValue {
             DataValue::Date32(value) => {
                 match to {
                     LogicalType::SqlNull => Ok(DataValue::Null),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.and_then(|v| {
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.and_then(|v| {
                         Self::date_format(v).map(|fmt| format!("{}", fmt))
                     }))),
                     LogicalType::Date => Ok(DataValue::Date32(value)),
@@ -558,7 +564,7 @@ impl DataValue {
             DataValue::Date64(value) => {
                 match to {
                     LogicalType::SqlNull => Ok(DataValue::Null),
-                    LogicalType::Varchar => Ok(DataValue::Utf8(value.and_then(|v| {
+                    LogicalType::Varchar(_) => Ok(DataValue::Utf8(value.and_then(|v| {
                         Self::date_time_format(v).map(|fmt| format!("{}", fmt))
                     }))),
                     LogicalType::Date => {


### PR DESCRIPTION
### What problem does this PR solve?

This commit revises the mechanism for checking limit conditions on variable length types such as varchar, moving the check from 'src/binder/insert.rs' to 'src/types/value.rs' to centralize the control. It also implements expression computation for the Udf8 data type. Furthermore, the now-unnecessary `Nvarchar` type has been removed. This overhaul enhances robustness against incorrect inputs in variable length fields and improves the computational abilities for the Utf8 data type.

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
