### PR TITLE
Implement indexes (currently only unique indexes are supported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Storage Support:
 ![demo](./static/images/demo.png)
 
 ### Features
+- SQL field options
+  - not null
+  - null
+  - unique
+- Supports index type
+  - Unique Index
 - Supports multiple primary key types
   - Tinyint
   - UTinyint
@@ -63,6 +69,8 @@ Storage Support:
   - [x] Truncate
 - DQL
   - [x] Select
+    - SeqScan
+    - IndexScan
   - [x] Where
   - [x] Distinct
   - [x] Alias

--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -34,8 +34,15 @@ impl<S: Storage> Binder<S> {
             .map(|col| ColumnCatalog::from(col.clone()))
             .collect_vec();
 
-        if columns.iter().find(|col| col.desc.is_primary).is_none() {
-            return Err(BindError::InvalidTable("At least one primary key field exists".to_string()));
+        let primary_key_count = columns
+            .iter()
+            .filter(|col| col.desc.is_primary)
+            .count();
+
+        if primary_key_count != 1 {
+            return Err(BindError::InvalidTable(
+                "The primary key field must exist and have at least one".to_string()
+            ));
         }
 
         let plan = LogicalPlan {
@@ -75,10 +82,10 @@ mod tests {
                 assert_eq!(op.table_name, Arc::new("t1".to_string()));
                 assert_eq!(op.columns[0].name, "id".to_string());
                 assert_eq!(op.columns[0].nullable, false);
-                assert_eq!(op.columns[0].desc, ColumnDesc::new(LogicalType::Integer, true));
+                assert_eq!(op.columns[0].desc, ColumnDesc::new(LogicalType::Integer, true, false));
                 assert_eq!(op.columns[1].name, "name".to_string());
                 assert_eq!(op.columns[1].nullable, true);
-                assert_eq!(op.columns[1].desc, ColumnDesc::new(LogicalType::Varchar(Some(10)), false));
+                assert_eq!(op.columns[1].desc, ColumnDesc::new(LogicalType::Varchar(Some(10)), false, false));
             }
             _ => unreachable!()
         }

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -64,7 +64,7 @@ impl<S: Storage> Binder<S> {
             let table_catalog = self
                 .context
                 .storage
-                .table_catalog(table)
+                .table(table)
                 .await
                 .ok_or_else(|| BindError::InvalidTable(table.to_string()))?;
 

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -24,7 +24,7 @@ impl<S: Storage> Binder<S> {
         let (_, name) = split_name(&name)?;
         let table_name = Arc::new(name.to_string());
 
-        if let Some(table) = self.context.storage.table_catalog(&table_name).await {
+        if let Some(table) = self.context.storage.table(&table_name).await {
             let mut columns = Vec::new();
 
             if idents.is_empty() {

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -211,7 +211,6 @@ pub mod test {
 
     pub async fn select_sql_run(sql: &str) -> Result<LogicalPlan, ExecutorError> {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
-
         let storage = build_test_catalog(temp_dir.path()).await?;
         let binder = Binder::new(BinderContext::new(storage));
         let stmt = crate::parser::parse_sql(sql)?;

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -193,16 +193,16 @@ pub mod test {
         let _ = storage.create_table(
             Arc::new("t1".to_string()),
             vec![
-                ColumnCatalog::new("c1".to_string(), false, ColumnDesc::new(Integer, true)),
-                ColumnCatalog::new("c2".to_string(), false, ColumnDesc::new(Integer, false)),
+                ColumnCatalog::new("c1".to_string(), false, ColumnDesc::new(Integer, true, true)),
+                ColumnCatalog::new("c2".to_string(), false, ColumnDesc::new(Integer, false, false)),
             ]
         ).await?;
 
         let _ = storage.create_table(
             Arc::new("t2".to_string()),
             vec![
-                ColumnCatalog::new("c3".to_string(), false, ColumnDesc::new(Integer, true)),
-                ColumnCatalog::new("c4".to_string(), false, ColumnDesc::new(Integer, false)),
+                ColumnCatalog::new("c3".to_string(), false, ColumnDesc::new(Integer, true, false)),
+                ColumnCatalog::new("c4".to_string(), false, ColumnDesc::new(Integer, false, false)),
             ]
         ).await?;
 

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -193,8 +193,8 @@ pub mod test {
         let _ = storage.create_table(
             Arc::new("t1".to_string()),
             vec![
-                ColumnCatalog::new("c1".to_string(), false, ColumnDesc::new(Integer, true, true)),
-                ColumnCatalog::new("c2".to_string(), false, ColumnDesc::new(Integer, false, false)),
+                ColumnCatalog::new("c1".to_string(), false, ColumnDesc::new(Integer, true, false)),
+                ColumnCatalog::new("c2".to_string(), false, ColumnDesc::new(Integer, false, true)),
             ]
         ).await?;
 

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -167,7 +167,7 @@ impl<S: Storage> Binder<S> {
         let table_catalog = self
             .context
             .storage
-            .table_catalog(&table_name)
+            .table(&table_name)
             .await
             .ok_or_else(|| BindError::InvalidTable(format!("bind table {}", table)))?;
 
@@ -215,7 +215,7 @@ impl<S: Storage> Binder<S> {
         for table_name in self.context.bind_table.keys().cloned() {
             let table = self.context
                 .storage
-                .table_catalog(&table_name)
+                .table(&table_name)
                 .await
                 .ok_or_else(|| BindError::InvalidTable(table_name.to_string()))?;
             for col in table.all_columns() {
@@ -244,12 +244,12 @@ impl<S: Storage> Binder<S> {
         let (right_table, right) = self.bind_single_table_ref(relation, Some(join_type)).await?;
 
         let left_table = self.context.storage
-            .table_catalog(&left_table)
+            .table(&left_table)
             .await
             .cloned()
             .ok_or_else(|| BindError::InvalidTable(format!("Left: {} not found", left_table)))?;
         let right_table = self.context.storage
-            .table_catalog(&right_table)
+            .table(&right_table)
             .await
             .cloned()
             .ok_or_else(|| BindError::InvalidTable(format!("Right: {} not found", right_table)))?;

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 use sqlparser::ast::{ColumnDef, ColumnOption};
 use crate::catalog::TableName;
 
-use crate::types::{ColumnId, IdGenerator, LogicalType};
+use crate::types::{ColumnId, LogicalType};
 
 pub type ColumnRef = Arc<ColumnCatalog>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub struct ColumnCatalog {
-    pub id: ColumnId,
+    pub id: Option<ColumnId>,
     pub name: String,
     pub table_name: Option<TableName>,
     pub nullable: bool,
@@ -19,7 +19,7 @@ pub struct ColumnCatalog {
 impl ColumnCatalog {
     pub(crate) fn new(column_name: String, nullable: bool, column_desc: ColumnDesc) -> ColumnCatalog {
         ColumnCatalog {
-            id: IdGenerator::build(),
+            id: None,
             name: column_name,
             table_name: None,
             nullable,

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -29,11 +29,11 @@ impl ColumnCatalog {
 
     pub(crate) fn new_dummy(column_name: String)-> ColumnCatalog {
         ColumnCatalog {
-            id: 0,
+            id: Some(0),
             name: column_name,
             table_name: None,
             nullable: false,
-            desc: ColumnDesc::new(LogicalType::Varchar(None), false),
+            desc: ColumnDesc::new(LogicalType::Varchar(None), false, false),
         }
     }
 

--- a/src/catalog/root.rs
+++ b/src/catalog/root.rs
@@ -35,7 +35,8 @@ impl RootCatalog {
         }
         let table = TableCatalog::new(
             table_name.clone(),
-            columns
+            columns,
+            vec![]
         )?;
 
         self.table_idxs.insert(table_name.clone(), table);
@@ -67,12 +68,12 @@ mod tests {
         let col0 = ColumnCatalog::new(
             "a".to_string(),
             false,
-            ColumnDesc::new(LogicalType::Integer, false),
+            ColumnDesc::new(LogicalType::Integer, false, false),
         );
         let col1 = ColumnCatalog::new(
             "b".to_string(),
             false,
-            ColumnDesc::new(LogicalType::Boolean, false),
+            ColumnDesc::new(LogicalType::Boolean, false, false),
         );
         let col_catalogs = vec![col0, col1];
 

--- a/src/catalog/root.rs
+++ b/src/catalog/root.rs
@@ -35,8 +35,7 @@ impl RootCatalog {
         }
         let table = TableCatalog::new(
             table_name.clone(),
-            columns,
-            vec![]
+            columns
         )?;
 
         self.table_idxs.insert(table_name.clone(), table);

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use itertools::Itertools;
 
 use crate::catalog::{CatalogError, ColumnCatalog, ColumnRef};
 use crate::types::ColumnId;
-use crate::types::index::IndexMeta;
+use crate::types::index::{IndexMeta, IndexRef};
 
 pub type TableName = Arc<String>;
 
@@ -13,11 +14,11 @@ pub struct TableCatalog {
     /// Mapping from column names to column ids
     column_idxs: BTreeMap<String, ColumnId>,
     pub(crate) columns: BTreeMap<ColumnId, ColumnRef>,
-    pub indexes: Vec<IndexMeta>
+    pub indexes: Vec<IndexRef>
 }
 
 impl TableCatalog {
-    pub(crate) fn get_unique_index(&self, col_id: &ColumnId) -> Option<&IndexMeta> {
+    pub(crate) fn get_unique_index(&self, col_id: &ColumnId) -> Option<&IndexRef> {
         self.indexes
             .iter()
             .find(|meta| meta.is_unique && &meta.column_ids[0] == col_id)
@@ -77,6 +78,10 @@ impl TableCatalog {
         columns: Vec<ColumnCatalog>,
         indexes: Vec<IndexMeta>
     ) -> Result<TableCatalog, CatalogError> {
+        let indexes = indexes.into_iter()
+            .map(Arc::new)
+            .collect_vec();
+
         let mut table_catalog = TableCatalog {
             name,
             column_idxs: BTreeMap::new(),

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::catalog::{CatalogError, ColumnCatalog, ColumnRef};
 use crate::types::ColumnId;
-use crate::types::index::IndexMeta;
+use crate::types::index::{IndexId, IndexMeta};
 
 pub type TableName = Arc<String>;
 
@@ -17,6 +17,12 @@ pub struct TableCatalog {
 }
 
 impl TableCatalog {
+    pub(crate) fn get_unique_index(&self, col_id: &ColumnId) -> Option<&IndexMeta> {
+        self.indexes
+            .iter()
+            .find(|meta| meta.is_unique && &meta.column_ids[0] == col_id)
+    }
+
     pub(crate) fn get_column_by_id(&self, id: &ColumnId) -> Option<&ColumnRef> {
         self.columns.get(id)
     }

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::catalog::{CatalogError, ColumnCatalog, ColumnRef};
 use crate::types::ColumnId;
-use crate::types::index::{IndexId, IndexMeta};
+use crate::types::index::IndexMeta;
 
 pub type TableName = Arc<String>;
 

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::catalog::{CatalogError, ColumnCatalog, ColumnRef};
 use crate::types::ColumnId;
-use crate::types::index::{IndexMeta, IndexRef};
+use crate::types::index::{IndexMeta, IndexMetaRef};
 
 pub type TableName = Arc<String>;
 
@@ -14,11 +14,11 @@ pub struct TableCatalog {
     /// Mapping from column names to column ids
     column_idxs: BTreeMap<String, ColumnId>,
     pub(crate) columns: BTreeMap<ColumnId, ColumnRef>,
-    pub indexes: Vec<IndexRef>
+    pub indexes: Vec<IndexMetaRef>
 }
 
 impl TableCatalog {
-    pub(crate) fn get_unique_index(&self, col_id: &ColumnId) -> Option<&IndexRef> {
+    pub(crate) fn get_unique_index(&self, col_id: &ColumnId) -> Option<&IndexMetaRef> {
         self.indexes
             .iter()
             .find(|meta| meta.is_unique && &meta.column_ids[0] == col_id)

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -62,8 +62,9 @@ impl TableCatalog {
             return Err(CatalogError::Duplicated("column", col.name.clone()));
         }
 
-        let col_id = col.id;
+        let col_id = self.columns.len() as u32;
 
+        col.id = Some(col_id);
         col.table_name = Some(self.name.clone());
         self.column_idxs.insert(col.name.clone(), col_id);
         self.columns.insert(col_id, Arc::new(col));

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use crate::catalog::{CatalogError, ColumnCatalog, ColumnRef};
 use crate::types::ColumnId;
+use crate::types::index::IndexMeta;
 
 pub type TableName = Arc<String>;
 
@@ -12,6 +13,7 @@ pub struct TableCatalog {
     /// Mapping from column names to column ids
     column_idxs: BTreeMap<String, ColumnId>,
     pub(crate) columns: BTreeMap<ColumnId, ColumnRef>,
+    pub indexes: Vec<IndexMeta>
 }
 
 impl TableCatalog {
@@ -66,11 +68,13 @@ impl TableCatalog {
     pub(crate) fn new(
         name: TableName,
         columns: Vec<ColumnCatalog>,
+        indexes: Vec<IndexMeta>
     ) -> Result<TableCatalog, CatalogError> {
         let mut table_catalog = TableCatalog {
             name,
             column_idxs: BTreeMap::new(),
             columns: BTreeMap::new(),
+            indexes,
         };
 
         for col_catalog in columns.into_iter() {
@@ -93,10 +97,10 @@ mod tests {
     // | 1         | true     |
     // | 2         | false    |
     fn test_table_catalog() {
-        let col0 = ColumnCatalog::new("a".into(), false, ColumnDesc::new(LogicalType::Integer, false));
-        let col1 = ColumnCatalog::new("b".into(), false, ColumnDesc::new(LogicalType::Boolean, false));
+        let col0 = ColumnCatalog::new("a".into(), false, ColumnDesc::new(LogicalType::Integer, false, false));
+        let col1 = ColumnCatalog::new("b".into(), false, ColumnDesc::new(LogicalType::Boolean, false, false));
         let col_catalogs = vec![col0, col1];
-        let table_catalog = TableCatalog::new(Arc::new("test".to_string()), col_catalogs).unwrap();
+        let table_catalog = TableCatalog::new(Arc::new("test".to_string()), col_catalogs, vec![]).unwrap();
 
         assert_eq!(table_catalog.contains_column(&"a".to_string()), true);
         assert_eq!(table_catalog.contains_column(&"b".to_string()), true);

--- a/src/db.rs
+++ b/src/db.rs
@@ -183,7 +183,7 @@ mod test {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
         let kipsql = Database::with_kipdb(temp_dir.path()).await?;
 
-        let _ = kipsql.run("create table t1 (a int primary key, b int unique, k int)").await?;
+        let _ = kipsql.run("create table t1 (a int primary key, b int unique null, k int)").await?;
         let _ = kipsql.run("create table t2 (c int primary key, d int unsigned null, e datetime)").await?;
         let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 3, 2)").await?;
         let _ = kipsql.run("insert into t2 (d, c, e) values (2, 1, '2021-05-20 21:00:00'), (3, 4, '2023-09-10 00:00:00')").await?;
@@ -279,7 +279,7 @@ mod test {
         println!("{}", create_table(&tuples_distinct_t1));
 
         println!("update t1 with filter:");
-        let _ = kipsql.run("update t1 set b = 0 where b > 1").await?;
+        let _ = kipsql.run("update t1 set b = 0 where b = 1").await?;
         println!("after t1:");
         let update_after_full_t1 = kipsql.run("select * from t1").await?;
         println!("{}", create_table(&update_after_full_t1));

--- a/src/db.rs
+++ b/src/db.rs
@@ -183,9 +183,9 @@ mod test {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
         let kipsql = Database::with_kipdb(temp_dir.path()).await?;
 
-        let _ = kipsql.run("create table t1 (a int primary key, b int, k int)").await?;
+        let _ = kipsql.run("create table t1 (a int primary key, b int unique, k int)").await?;
         let _ = kipsql.run("create table t2 (c int primary key, d int unsigned null, e datetime)").await?;
-        let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 2, 2)").await?;
+        let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 3, 2)").await?;
         let _ = kipsql.run("insert into t2 (d, c, e) values (2, 1, '2021-05-20 21:00:00'), (3, 4, '2023-09-10 00:00:00')").await?;
 
         println!("full t1:");
@@ -285,13 +285,15 @@ mod test {
         println!("{}", create_table(&update_after_full_t1));
 
         println!("insert overwrite t1:");
-        let _ = kipsql.run("insert overwrite t1 (a, b, k) values (-1, 1, 1)").await?;
+        let _ = kipsql.run("insert overwrite t1 (a, b, k) values (-99, 1, 0)").await?;
         println!("after t1:");
         let insert_overwrite_after_full_t1 = kipsql.run("select * from t1").await?;
         println!("{}", create_table(&insert_overwrite_after_full_t1));
 
+        assert!(kipsql.run("insert overwrite t1 (a, b, k) values (-1, 1, 0)").await.is_err());
+
         println!("delete t1 with filter:");
-        let _ = kipsql.run("delete from t1 where b > 1").await?;
+        let _ = kipsql.run("delete from t1 where b = 0").await?;
         println!("after t1:");
         let delete_after_full_t1 = kipsql.run("select * from t1").await?;
         println!("{}", create_table(&delete_after_full_t1));

--- a/src/db.rs
+++ b/src/db.rs
@@ -201,6 +201,10 @@ mod test {
         let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 3, 2)").await?;
         let _ = kipsql.run("insert into t2 (d, c, e) values (2, 1, '2021-05-20 21:00:00'), (3, 4, '2023-09-10 00:00:00')").await?;
 
+        println!("show tables:");
+        let tuples_show_tables = kipsql.run("show tables").await?;
+        println!("{}", create_table(&tuples_show_tables));
+
         println!("full t1:");
         let tuples_full_fields_t1 = kipsql.run("select * from t1").await?;
         println!("{}", create_table(&tuples_full_fields_t1));
@@ -316,10 +320,6 @@ mod test {
 
         println!("drop t1:");
         let _ = kipsql.run("drop table t1").await?;
-
-        println!("show tables:");
-        let tuples_show_tables = kipsql.run("show tables").await?;
-        println!("{}", create_table(&tuples_show_tables));
 
         Ok(())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,7 @@ use crate::execution::ExecutorError;
 use crate::execution::executor::{build, try_collect};
 use crate::optimizer::heuristic::batch::HepBatchStrategy;
 use crate::optimizer::heuristic::optimizer::HepOptimizer;
+use crate::optimizer::OptimizerError;
 use crate::optimizer::rule::RuleImpl;
 use crate::parser::parse_sql;
 use crate::planner::LogicalPlan;
@@ -64,7 +65,7 @@ impl<S: Storage> Database<S> {
         // println!("source_plan plan: {:#?}", source_plan);
 
         let best_plan = Self::default_optimizer(source_plan)
-            .find_best();
+            .find_best()?;
         // println!("best_plan plan: {:#?}", best_plan);
 
         let mut stream = build(best_plan, &self.storage);
@@ -138,6 +139,12 @@ pub enum DatabaseError {
     ),
     #[error("Internal error: {0}")]
     InternalError(String),
+    #[error("optimizer error: {0}")]
+    OptimizerError(
+        #[source]
+        #[from]
+        OptimizerError
+    )
 }
 
 #[cfg(test)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -76,6 +76,11 @@ impl<S: Storage> Database<S> {
     fn default_optimizer(source_plan: LogicalPlan) -> HepOptimizer {
         HepOptimizer::new(source_plan)
             .batch(
+                "Simplify Filter".to_string(),
+                HepBatchStrategy::fix_point_topdown(10),
+                vec![RuleImpl::SimplifyFilter]
+            )
+            .batch(
                 "Predicate Pushdown".to_string(),
                 HepBatchStrategy::fix_point_topdown(10),
                 vec![
@@ -107,11 +112,6 @@ impl<S: Storage> Database<S> {
                     RuleImpl::CollapseProject,
                     RuleImpl::CombineFilter
                 ]
-            )
-            .batch(
-                "Simplify Filter".to_string(),
-                HepBatchStrategy::fix_point_topdown(10),
-                vec![RuleImpl::SimplifyFilter]
             )
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -76,14 +76,14 @@ impl<S: Storage> Database<S> {
     fn default_optimizer(source_plan: LogicalPlan) -> HepOptimizer {
         HepOptimizer::new(source_plan)
             .batch(
-                "Predicate pushdown".to_string(),
+                "Predicate Pushdown".to_string(),
                 HepBatchStrategy::fix_point_topdown(10),
                 vec![
                     RuleImpl::PushPredicateThroughJoin
                 ]
             )
             .batch(
-                "Limit pushdown".to_string(),
+                "Limit Pushdown".to_string(),
                 HepBatchStrategy::fix_point_topdown(10),
                 vec![
                     RuleImpl::LimitProjectTranspose,
@@ -93,7 +93,7 @@ impl<S: Storage> Database<S> {
                 ],
             )
             .batch(
-                "Column pruning".to_string(),
+                "Column Pruning".to_string(),
                 HepBatchStrategy::fix_point_topdown(10),
                 vec![
                     RuleImpl::PushProjectThroughChild,
@@ -101,12 +101,17 @@ impl<S: Storage> Database<S> {
                 ]
             )
             .batch(
-                "Combine operators".to_string(),
+                "Combine Operators".to_string(),
                 HepBatchStrategy::fix_point_topdown(10),
                 vec![
                     RuleImpl::CollapseProject,
                     RuleImpl::CombineFilter
                 ]
+            )
+            .batch(
+                "Simplify Filter".to_string(),
+                HepBatchStrategy::fix_point_topdown(10),
+                vec![RuleImpl::SimplifyFilter]
             )
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -210,7 +210,7 @@ mod test {
         println!("{}", create_table(&tuples_full_fields_t2));
 
         println!("projection_and_filter:");
-        let tuples_projection_and_filter = kipsql.run("select a from t1 where a <= 1").await?;
+        let tuples_projection_and_filter = kipsql.run("select a from t1 where b > 1").await?;
         println!("{}", create_table(&tuples_projection_and_filter));
 
         println!("projection_and_sort:");

--- a/src/db.rs
+++ b/src/db.rs
@@ -196,9 +196,9 @@ mod test {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
         let kipsql = Database::with_kipdb(temp_dir.path()).await?;
 
-        let _ = kipsql.run("create table t1 (a int primary key, b int unique null, k int)").await?;
+        let _ = kipsql.run("create table t1 (a int primary key, b int unique null, k int, z varchar unique null)").await?;
         let _ = kipsql.run("create table t2 (c int primary key, d int unsigned null, e datetime)").await?;
-        let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 3, 2)").await?;
+        let _ = kipsql.run("insert into t1 (a, b, k, z) values (-99, 1, 1, 'k'), (-1, 2, 2, 'i'), (5, 3, 2, 'p')").await?;
         let _ = kipsql.run("insert into t2 (d, c, e) values (2, 1, '2021-05-20 21:00:00'), (3, 4, '2023-09-10 00:00:00')").await?;
         let _ = kipsql.run("create table t3 (a int primary key, b decimal(4,2))").await?;
         let _ = kipsql.run("insert into t3 (a, b) values (1, 1111), (2, 2.01), (3, 3.00)").await?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -84,7 +84,16 @@ impl<S: Storage> Database<S> {
                 "Predicate Pushdown".to_string(),
                 HepBatchStrategy::fix_point_topdown(10),
                 vec![
-                    RuleImpl::PushPredicateThroughJoin
+                    RuleImpl::PushPredicateThroughJoin,
+                    RuleImpl::PushPredicateIntoScan
+                ]
+            )
+            .batch(
+                "Column Pruning".to_string(),
+                HepBatchStrategy::fix_point_topdown(10),
+                vec![
+                    RuleImpl::PushProjectThroughChild,
+                    RuleImpl::PushProjectIntoScan
                 ]
             )
             .batch(
@@ -96,14 +105,6 @@ impl<S: Storage> Database<S> {
                     RuleImpl::PushLimitIntoTableScan,
                     RuleImpl::EliminateLimits,
                 ],
-            )
-            .batch(
-                "Column Pruning".to_string(),
-                HepBatchStrategy::fix_point_topdown(10),
-                vec![
-                    RuleImpl::PushProjectThroughChild,
-                    RuleImpl::PushProjectIntoScan
-                ]
             )
             .batch(
                 "Combine Operators".to_string(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -155,12 +155,12 @@ mod test {
             ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true)
+                ColumnDesc::new(LogicalType::Integer, true, false)
             ),
             ColumnCatalog::new(
                 "c2".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Boolean, false)
+                ColumnDesc::new(LogicalType::Boolean, false, false)
             ),
         ];
 
@@ -182,6 +182,7 @@ mod test {
     async fn test_crud_sql() -> Result<(), DatabaseError> {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
         let kipsql = Database::with_kipdb(temp_dir.path()).await?;
+
         let _ = kipsql.run("create table t1 (a int primary key, b int, k int)").await?;
         let _ = kipsql.run("create table t2 (c int primary key, d int unsigned null, e datetime)").await?;
         let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 2, 2)").await?;

--- a/src/execution/executor/dml/delete.rs
+++ b/src/execution/executor/dml/delete.rs
@@ -41,8 +41,10 @@ impl Delete {
                 .into_iter()
                 .enumerate()
                 .filter_map(|(i, col)| col.desc.is_unique
-                    .then(|| table_catalog.get_unique_index(&col.id)
-                        .map(|index_meta| (i, index_meta)))
+                    .then(|| col.id.and_then(|col_id| {
+                        table_catalog.get_unique_index(&col_id)
+                            .map(|index_meta| (i, index_meta))
+                    }))
                     .flatten())
                 .collect_vec();
 

--- a/src/execution/executor/dml/insert.rs
+++ b/src/execution/executor/dml/insert.rs
@@ -8,6 +8,7 @@ use crate::execution::ExecutorError;
 use crate::planner::operator::insert::InsertOperator;
 use crate::storage::{Storage, Table};
 use crate::types::ColumnId;
+use crate::types::index::{Index, IndexValue};
 use crate::types::tuple::Tuple;
 use crate::types::value::{DataValue, ValueRef};
 
@@ -38,6 +39,7 @@ impl Insert {
     pub async fn _execute<S: Storage>(self, storage: S) {
         let Insert { table_name, input, is_overwrite } = self;
         let mut primary_key_index = None;
+        let mut unique_values = HashMap::new();
 
         if let (Some(table_catalog), Some(mut table)) =
             (storage.table_catalog(&table_name).await, storage.table(&table_name).await)
@@ -51,16 +53,15 @@ impl Insert {
                         .map(|(i, _)| i)
                         .unwrap()
                 });
-                let id = Some(values[*primary_idx].clone());
+                let id = values[*primary_idx].clone();
                 let mut tuple_map: HashMap<ColumnId, ValueRef> = values
                     .into_iter()
                     .enumerate()
                     .map(|(i, value)| (columns[i].id, value))
                     .collect();
                 let all_columns = table_catalog.all_columns_with_id();
-
                 let mut tuple = Tuple {
-                    id,
+                    id: Some(id.clone()),
                     columns: Vec::with_capacity(all_columns.len()),
                     values: Vec::with_capacity(all_columns.len()),
                 };
@@ -69,6 +70,12 @@ impl Insert {
                     let value = tuple_map.remove(col_id)
                         .unwrap_or_else(|| Arc::new(DataValue::none(col.datatype())));
 
+                    if col.desc.is_unique {
+                        unique_values
+                            .entry(col.id)
+                            .or_insert_with(|| vec![])
+                            .push((id.clone(), value.clone()))
+                    }
                     if value.is_null() && !col.nullable {
                         return Err(ExecutorError::InternalError(format!("Non-null fields do not allow null values to be passed in: {:?}", col)));
                     }
@@ -79,6 +86,23 @@ impl Insert {
 
                 table.append(tuple, is_overwrite)?;
             }
+            // Unique Index
+            for (col_id, values) in unique_values {
+                if let Some(index_meta) = table_catalog.get_unique_index(&col_id) {
+                    for (tuple_id, value) in values {
+                        let index = Index {
+                            id: index_meta.id,
+                            column_values: vec![value],
+                            value: IndexValue {
+                                tuple_ids: vec![tuple_id],
+                            },
+                        };
+
+                        table.add_index(index, true)?;
+                    }
+                }
+            }
+
             table.commit().await?;
         }
     }

--- a/src/execution/executor/dml/insert.rs
+++ b/src/execution/executor/dml/insert.rs
@@ -8,7 +8,7 @@ use crate::execution::ExecutorError;
 use crate::planner::operator::insert::InsertOperator;
 use crate::storage::{Storage, Table};
 use crate::types::ColumnId;
-use crate::types::index::{Index, IndexValue};
+use crate::types::index::Index;
 use crate::types::tuple::Tuple;
 use crate::types::value::{DataValue, ValueRef};
 
@@ -70,7 +70,7 @@ impl Insert {
                     let value = tuple_map.remove(col_id)
                         .unwrap_or_else(|| Arc::new(DataValue::none(col.datatype())));
 
-                    if col.desc.is_unique {
+                    if col.desc.is_unique && !value.is_null() {
                         unique_values
                             .entry(col.id)
                             .or_insert_with(|| vec![])
@@ -93,12 +93,9 @@ impl Insert {
                         let index = Index {
                             id: index_meta.id,
                             column_values: vec![value],
-                            value: IndexValue {
-                                tuple_ids: vec![tuple_id],
-                            },
                         };
 
-                        table.add_index(index, true)?;
+                        table.add_index(index, vec![tuple_id], true)?;
                     }
                 }
             }

--- a/src/execution/executor/dml/insert.rs
+++ b/src/execution/executor/dml/insert.rs
@@ -57,7 +57,7 @@ impl Insert {
                 let mut tuple_map: HashMap<ColumnId, ValueRef> = values
                     .into_iter()
                     .enumerate()
-                    .map(|(i, value)| (columns[i].id, value))
+                    .filter_map(|(i, value)| columns[i].id.map(|id| (id, value)))
                     .collect();
                 let all_columns = table_catalog.all_columns_with_id();
                 let mut tuple = Tuple {
@@ -88,7 +88,7 @@ impl Insert {
             }
             // Unique Index
             for (col_id, values) in unique_values {
-                if let Some(index_meta) = table_catalog.get_unique_index(&col_id) {
+                if let Some(index_meta) = table_catalog.get_unique_index(&col_id.unwrap()) {
                     for (tuple_id, value) in values {
                         let index = Index {
                             id: index_meta.id,

--- a/src/execution/executor/dml/update.rs
+++ b/src/execution/executor/dml/update.rs
@@ -61,7 +61,7 @@ impl Update {
                             is_overwrite = false;
                         }
                         if column.desc.is_unique && value != &tuple.values[i] {
-                            if let Some(index_meta) = table_catalog.get_unique_index(&column.id) {
+                            if let Some(index_meta) = table_catalog.get_unique_index(&column.id.unwrap()) {
                                 let mut index = Index {
                                     id: index_meta.id,
                                     column_values: vec![tuple.values[i].clone()],

--- a/src/execution/executor/dql/aggregate/hash_agg.rs
+++ b/src/execution/executor/dql/aggregate/hash_agg.rs
@@ -122,7 +122,7 @@ mod test {
     #[tokio::test]
     async fn test_hash_agg() -> Result<(), ExecutorError> {
         let mem_storage = MemStorage::new();
-        let desc = ColumnDesc::new(LogicalType::Integer, false);
+        let desc = ColumnDesc::new(LogicalType::Integer, false, false);
 
         let t1_columns = vec![
             Arc::new(ColumnCatalog::new("c1".to_string(), true, desc.clone())),

--- a/src/execution/executor/dql/index_scan.rs
+++ b/src/execution/executor/dql/index_scan.rs
@@ -1,0 +1,46 @@
+use futures_async_stream::try_stream;
+use crate::execution::executor::{BoxedExecutor, Executor};
+use crate::execution::ExecutorError;
+use crate::planner::operator::scan::ScanOperator;
+use crate::storage::{Iter, Storage, Transaction};
+use crate::types::errors::TypeError;
+use crate::types::tuple::Tuple;
+
+pub(crate) struct IndexScan {
+    op: ScanOperator
+}
+
+impl From<ScanOperator> for IndexScan {
+    fn from(op: ScanOperator) -> Self {
+        IndexScan {
+            op
+        }
+    }
+}
+
+impl<S: Storage> Executor<S> for IndexScan {
+    fn execute(self, storage: &S) -> BoxedExecutor {
+        self._execute(storage.clone())
+    }
+}
+
+impl IndexScan {
+    #[try_stream(boxed, ok = Tuple, error = ExecutorError)]
+    pub async fn _execute<S: Storage>(self, storage: S) {
+        let ScanOperator { table_name, columns, limit, index_by, .. } = self.op;
+        let (index_meta, binaries) = index_by.ok_or(TypeError::InvalidType)?;
+
+        if let Some(transaction) = storage.transaction(&table_name).await {
+            let mut iter = transaction.read_by_index(
+                limit,
+                columns,
+                index_meta,
+                binaries
+            )?;
+
+            while let Some(tuple) =  iter.next_tuple()? {
+                yield tuple;
+            }
+        }
+    }
+}

--- a/src/execution/executor/dql/join/hash_join.rs
+++ b/src/execution/executor/dql/join/hash_join.rs
@@ -231,7 +231,7 @@ mod test {
     use crate::types::value::DataValue;
 
     fn build_join_values<S: Storage>(_s: &S) -> (Vec<(ScalarExpression, ScalarExpression)>, BoxedExecutor, BoxedExecutor) {
-        let desc = ColumnDesc::new(LogicalType::Integer, false);
+        let desc = ColumnDesc::new(LogicalType::Integer, false, false);
 
         let t1_columns = vec![
             Arc::new(ColumnCatalog::new("c1".to_string(), true, desc.clone())),

--- a/src/execution/executor/dql/mod.rs
+++ b/src/execution/executor/dql/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod limit;
 pub(crate) mod join;
 pub(crate) mod dummy;
 pub(crate) mod aggregate;
+pub(crate) mod index_scan;
 
 #[cfg(test)]
 pub(crate) mod test {

--- a/src/execution/executor/show/show_table.rs
+++ b/src/execution/executor/show/show_table.rs
@@ -30,23 +30,21 @@ impl<S: Storage> Executor<S> for ShowTables {
 impl ShowTables {
     #[try_stream(boxed, ok = Tuple, error = ExecutorError)]
     pub async fn _execute<S: Storage>(self, storage: S) {
-        if let Some(tables) = storage.show_tables().await {
-            for (table,column_count) in tables {
-                let columns: Vec<ColumnRef> = vec![
-                    Arc::new(ColumnCatalog::new_dummy("TABLES".to_string())),
-                    Arc::new(ColumnCatalog::new_dummy("COLUMN_COUNT".to_string())),
-                ];
-                let values: Vec<ValueRef> = vec![
-                    Arc::new(DataValue::Utf8(Some(table))),
-                    Arc::new(DataValue::UInt32(Some(column_count as u32))),
-                ];
+        let tables = storage.show_tables().await?;
 
-                yield Tuple {
-                    id: None,
-                    columns,
-                    values,
-                };
-            }
+        for table in tables {
+            let columns: Vec<ColumnRef> = vec![
+                Arc::new(ColumnCatalog::new_dummy("TABLES".to_string())),
+            ];
+            let values: Vec<ValueRef> = vec![
+                Arc::new(DataValue::Utf8(Some(table))),
+            ];
+
+            yield Tuple {
+                id: None,
+                columns,
+                values,
+            };
         }
     }
 }

--- a/src/execution/executor/show/show_table.rs
+++ b/src/execution/executor/show/show_table.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 use crate::types::value::{DataValue, ValueRef};
 
 pub struct ShowTables {
-    op: ShowTablesOperator,
+    _op: ShowTablesOperator,
 }
 
 impl From<ShowTablesOperator> for ShowTables {
     fn from(op: ShowTablesOperator) -> Self {
         ShowTables {
-            op
+            _op: op
         }
     }
 }

--- a/src/expression/evaluator.rs
+++ b/src/expression/evaluator.rs
@@ -33,8 +33,10 @@ impl ScalarExpression {
                 Ok(Arc::new(binary_op(&left, &right, op)?))
             }
             ScalarExpression::IsNull{ expr } => {
-                Ok(Arc::new(DataValue::Boolean(Some(expr.nullable()))))
-            }
+                let value = expr.eval_column(tuple)?;
+
+                Ok(Arc::new(DataValue::Boolean(Some(value.is_null()))))
+            },
             ScalarExpression::Unary{ expr, op, .. } => {
                 let value = expr.eval_column(tuple)?;
 

--- a/src/expression/index.rs
+++ b/src/expression/index.rs
@@ -1,0 +1,612 @@
+use std::cmp::Ordering;
+use std::collections::Bound;
+use std::mem;
+use std::sync::Arc;
+use crate::catalog::ColumnRef;
+use crate::expression::{BinaryOperator, ScalarExpression};
+use crate::expression::value_compute::{binary_op, unary_op};
+use crate::types::{ColumnId, LogicalType};
+use crate::types::errors::TypeError;
+use crate::types::value::{DataValue, ValueRef};
+
+#[derive(Debug, PartialEq)]
+pub enum IndexBinary {
+    Scope {
+        min: Bound<ValueRef>,
+        max: Bound<ValueRef>
+    },
+    Eq(ValueRef),
+    NotEq(ValueRef),
+
+    And(Vec<IndexBinary>),
+    Or(Vec<IndexBinary>)
+}
+
+
+impl IndexBinary {
+    fn is_null(&self) -> Result<bool, TypeError> {
+        match self {
+            IndexBinary::Scope { min, max } => Ok(matches!((min, max), (Bound::Unbounded, Bound::Unbounded))),
+            IndexBinary::Eq(val) | IndexBinary::NotEq(val) => Ok(val.is_null()),
+            _ => Err(TypeError::InvalidType),
+        }
+    }
+
+    // FIXME: 聚合时将scope以外的等值条件已经非等值条件去除
+    // Tips: Not `And` and `Or`
+    pub fn scope_aggregation(binaries: Vec<IndexBinary>) -> Result<Vec<IndexBinary>, TypeError> {
+        fn bound_compared(left_bound: &Bound<ValueRef>, right_bound: &Bound<ValueRef>, is_min: bool) -> Option<Ordering> {
+            let op = |is_min, order: Ordering| {
+                if is_min {
+                    order
+                } else {
+                    order.reverse()
+                }
+            };
+
+            match (left_bound, right_bound) {
+                (Bound::Unbounded, Bound::Unbounded) => Some(Ordering::Equal),
+                (Bound::Unbounded, _) => Some(op(is_min, Ordering::Less)),
+                (_, Bound::Unbounded) => Some(op(is_min, Ordering::Greater)),
+                (Bound::Included(left), Bound::Included(right)) => left.partial_cmp(right),
+                (Bound::Included(left), Bound::Excluded(right)) => {
+                    left.partial_cmp(right)
+                        .map(|order| order.then(op(is_min, Ordering::Less)))
+                },
+                (Bound::Excluded(left), Bound::Excluded(right)) => left.partial_cmp(right),
+                (Bound::Excluded(left), Bound::Included(right)) => {
+                    left.partial_cmp(right)
+                        .map(|order| order.then(op(is_min, Ordering::Greater)))
+                },
+            }
+        }
+
+        let mut new_binaries = Vec::new();
+        let mut scope_min = Bound::Unbounded;
+        let mut scope_max = Bound::Unbounded;
+
+        for binary in binaries {
+            if let IndexBinary::Scope { min, max } = binary {
+                if let Some(order) = bound_compared(&scope_min, &min, true) {
+                    if order.is_lt() {
+                        scope_min = min;
+                    }
+                }
+
+                if let Some(order) = bound_compared(&scope_max, &max, false) {
+                    if order.is_gt() {
+                        scope_max = max;
+                    }
+                }
+            } else if !binary.is_null()? {
+                new_binaries.push(binary);
+            }
+        }
+        if !matches!((&scope_min, &scope_max), (Bound::Unbounded, Bound::Unbounded)) {
+            new_binaries.push(IndexBinary::Scope {
+                min: scope_min,
+                max: scope_max,
+            })
+        }
+
+        Ok(new_binaries)
+    }
+}
+
+struct ReplaceBinary {
+    column_expr: ScalarExpression,
+    val_expr: ScalarExpression,
+    op: BinaryOperator,
+    ty: LogicalType,
+    is_column_left: bool
+}
+
+impl ScalarExpression {
+    fn unpack_val(&self) -> Option<ValueRef> {
+        match self {
+            ScalarExpression::Constant(val) => Some(val.clone()),
+            ScalarExpression::Alias { expr, .. } => expr.unpack_val(),
+            ScalarExpression::TypeCast { expr, ty, .. } => {
+                expr.unpack_val()
+                    .and_then(|val| DataValue::clone(&val)
+                        .cast(ty).ok()
+                        .map(Arc::new))
+            }
+            ScalarExpression::IsNull { expr } => {
+                let is_null = expr.unpack_val().map(|val| val.is_null());
+
+                Some(Arc::new(DataValue::Boolean(is_null)))
+            },
+            ScalarExpression::Unary { expr, op, .. } => {
+                let val = expr.unpack_val()?;
+
+                unary_op(&val, op).ok()
+                    .map(Arc::new)
+
+            }
+            ScalarExpression::Binary { left_expr, right_expr, op, .. } => {
+                let left = left_expr.unpack_val()?;
+                let right = right_expr.unpack_val()?;
+
+                binary_op(&left, &right, op).ok()
+                    .map(Arc::new)
+            }
+            _ => None
+        }
+    }
+
+    fn unpack_col(&self, is_binary_then_return: bool) -> Option<ColumnRef> {
+        match self {
+            ScalarExpression::ColumnRef(col) => Some(col.clone()),
+            ScalarExpression::Alias { expr, .. } => expr.unpack_col(is_binary_then_return),
+            ScalarExpression::Binary { left_expr, right_expr, .. } => {
+                if is_binary_then_return {
+                    return None;
+                }
+
+                match (left_expr.unpack_col(is_binary_then_return),
+                       right_expr.unpack_col(is_binary_then_return))
+                {
+                    (Some(col), None) | (None, Some(col)) => Some(col),
+                    _ => None
+                }
+            }
+            _ => None
+        }
+    }
+
+    // Tips: Indirect expressions like `ScalarExpression:：Alias` will be lost
+    fn arithmetic_flip(&mut self, col_id: &ColumnId, fix_option: &mut Option<ReplaceBinary>) {
+        match self {
+            ScalarExpression::Binary { left_expr, right_expr, op, ty } => {
+                let mut is_fixed = false;
+
+                left_expr.arithmetic_flip(col_id, fix_option);
+                is_fixed = fix_option.is_some();
+                Self::fix_binary(fix_option, left_expr, right_expr, op);
+
+                // `(c1 - 1) and (c1 + 2)` cannot fix!
+                if fix_option.is_none() && !is_fixed {
+                    right_expr.arithmetic_flip(col_id, fix_option);
+                    Self::fix_binary(fix_option, right_expr, left_expr, op);
+                }
+
+                if matches!(op, BinaryOperator::Plus | BinaryOperator::Divide
+                    | BinaryOperator::Minus | BinaryOperator::Multiply)
+                {
+                    match (left_expr.unpack_col(true), right_expr.unpack_col(true)) {
+                        (Some(_), Some(_)) => (),
+                        (Some(col), None) => {
+                            if col_id != &col.id{
+                                return;
+                            }
+                            fix_option.replace(ReplaceBinary{
+                                column_expr: ScalarExpression::ColumnRef(col),
+                                val_expr: right_expr.as_ref().clone(),
+                                op: *op,
+                                ty: *ty,
+                                is_column_left: true,
+                            });
+                        }
+                        (None, Some(col)) => {
+                            if col_id != &col.id{
+                                return;
+                            }
+                            fix_option.replace(ReplaceBinary{
+                                column_expr: ScalarExpression::ColumnRef(col),
+                                val_expr: left_expr.as_ref().clone(),
+                                op: *op,
+                                ty: *ty,
+                                is_column_left: false,
+                            });
+                        }
+                        _ => ()
+                    }
+                }
+            }
+            ScalarExpression::Alias { expr, .. } => expr.arithmetic_flip(col_id, fix_option),
+            ScalarExpression::TypeCast { expr, .. } => expr.arithmetic_flip(col_id, fix_option),
+            ScalarExpression::IsNull { expr, .. } => expr.arithmetic_flip(col_id, fix_option),
+            ScalarExpression::Unary { expr, .. } => expr.arithmetic_flip(col_id, fix_option),
+            _ => ()
+        }
+    }
+
+    fn fix_binary(fix_option: &mut Option<ReplaceBinary>, left_expr: &mut Box<ScalarExpression>, right_expr: &mut Box<ScalarExpression>, op: &mut BinaryOperator) {
+        if let Some(ReplaceBinary { column_expr, val_expr, op: fix_op, ty: fix_ty, is_column_left })
+            = fix_option.take()
+        {
+            let op_flip = |op: BinaryOperator| {
+                match op {
+                    BinaryOperator::Plus => BinaryOperator::Minus,
+                    BinaryOperator::Minus => BinaryOperator::Plus,
+                    BinaryOperator::Multiply => BinaryOperator::Divide,
+                    BinaryOperator::Divide => BinaryOperator::Multiply,
+                    _ => unreachable!()
+                }
+            };
+            let comparison_flip = |op: BinaryOperator| {
+                match op {
+                    BinaryOperator::Gt => BinaryOperator::Lt,
+                    BinaryOperator::GtEq => BinaryOperator::LtEq,
+                    BinaryOperator::Lt => BinaryOperator::Gt,
+                    BinaryOperator::LtEq => BinaryOperator::GtEq,
+                    source_op => source_op
+                }
+            };
+            let (fixed_op, fixed_left_expr, fixed_right_expr) = if is_column_left {
+                (op_flip(fix_op), right_expr.clone(), Box::new(val_expr))
+            } else {
+                if matches!(fix_op, BinaryOperator::Minus | BinaryOperator::Multiply) {
+                    let _ = mem::replace(op, comparison_flip(*op));
+                }
+                (fix_op, Box::new(val_expr), right_expr.clone())
+            };
+
+            let _ = mem::replace(left_expr, Box::new(column_expr));
+            let _ = mem::replace(right_expr, Box::new(ScalarExpression::Binary {
+                op: fixed_op,
+                left_expr: fixed_left_expr,
+                right_expr: fixed_right_expr,
+                ty: fix_ty,
+            }));
+        }
+    }
+
+    pub fn convert_binary(&self, col_id: &ColumnId) -> Result<Option<IndexBinary>, TypeError> {
+        let mut expr = self.clone();
+
+        expr.arithmetic_flip(col_id, &mut None);
+
+        match &expr {
+            ScalarExpression::Binary { left_expr, right_expr, op, .. } => {
+                match (left_expr.convert_binary(col_id)?, right_expr.convert_binary(col_id)?) {
+                    (Some(left_binary), Some(right_binary)) => {
+                        match (left_binary, right_binary) {
+                            (IndexBinary::And(mut left), IndexBinary::And(mut right))
+                            | (IndexBinary::Or(mut left), IndexBinary::Or(mut right)) => {
+                                left.append(&mut right);
+
+                                Ok(Some(IndexBinary::And(left)))
+                            }
+                            (IndexBinary::And(mut left), IndexBinary::Or(mut right)) => {
+                                right.append(&mut left);
+
+                                Ok(Some(IndexBinary::Or(right)))
+                            }
+                            (IndexBinary::Or(mut left), IndexBinary::And(mut right)) => {
+                                left.append(&mut right);
+
+                                Ok(Some(IndexBinary::Or(left)))
+                            }
+                            (IndexBinary::And(mut binaries), binary)
+                            | (binary, IndexBinary::And(mut binaries)) => {
+                                binaries.push(binary);
+
+                                Ok(Some(IndexBinary::And(binaries)))
+                            }
+                            (IndexBinary::Or(mut binaries), binary)
+                            | (binary, IndexBinary::Or(mut binaries)) => {
+                                binaries.push(binary);
+
+                                Ok(Some(IndexBinary::Or(binaries)))
+                            }
+                            (left, right) => {
+                                match op {
+                                    BinaryOperator::And => {
+                                        Ok(Some(IndexBinary::And(vec![left, right])))
+                                    }
+                                    BinaryOperator::Or => {
+                                        Ok(Some(IndexBinary::Or(vec![left, right])))
+                                    }
+                                    BinaryOperator::Xor => todo!(),
+                                    _ => Ok(None)
+                                }
+                            }
+                        }
+                    },
+                    (None, None) => {
+                        if let (Some(col), Some(val)) = (left_expr.unpack_col(false), right_expr.unpack_val()) {
+                            if !col.id == *col_id {
+                                return Ok(None);
+                            }
+
+                            return match op {
+                                BinaryOperator::Gt => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Excluded(val.clone()),
+                                        max: Bound::Unbounded
+                                    }))
+                                }
+                                BinaryOperator::Lt => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Unbounded,
+                                        max: Bound::Excluded(val.clone()),
+                                    }))
+                                }
+                                BinaryOperator::GtEq => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Included(val.clone()),
+                                        max: Bound::Unbounded
+                                    }))
+                                }
+                                BinaryOperator::LtEq => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Unbounded,
+                                        max: Bound::Included(val.clone()),
+                                    }))
+                                }
+                                BinaryOperator::Eq | BinaryOperator::Spaceship => {
+                                    Ok(Some(IndexBinary::Eq(val.clone())))
+                                },
+                                BinaryOperator::NotEq => {
+                                    Ok(Some(IndexBinary::NotEq(val.clone())))
+                                },
+                                _ => Ok(None)
+                            };
+                        }
+                        if let (Some(val), Some(col)) = (left_expr.unpack_val(), right_expr.unpack_col(false)) {
+                            if !col.id == *col_id {
+                                return Ok(None);
+                            }
+
+                            return match op {
+                                BinaryOperator::Gt => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Unbounded,
+                                        max: Bound::Excluded(val.clone())
+                                    }))
+                                }
+                                BinaryOperator::Lt => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Excluded(val.clone()),
+                                        max: Bound::Unbounded,
+                                    }))
+                                }
+                                BinaryOperator::GtEq => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Unbounded,
+                                        max: Bound::Included(val.clone())
+                                    }))
+                                }
+                                BinaryOperator::LtEq => {
+                                    Ok(Some(IndexBinary::Scope {
+                                        min: Bound::Included(val.clone()),
+                                        max: Bound::Unbounded,
+                                    }))
+                                }
+                                BinaryOperator::Eq | BinaryOperator::Spaceship => {
+                                    Ok(Some(IndexBinary::Eq(val.clone())))
+                                },
+                                BinaryOperator::NotEq => {
+                                    Ok(Some(IndexBinary::NotEq(val.clone())))
+                                },
+                                _ => Ok(None)
+                            };
+                        }
+
+                        return Ok(None);
+                    }
+                    (Some(binary), None) | (None, Some(binary)) => return Ok(Some(binary)),
+                }
+            },
+            ScalarExpression::Alias { expr, .. } => expr.convert_binary(col_id),
+            ScalarExpression::TypeCast { expr, .. } => expr.convert_binary(col_id),
+            ScalarExpression::IsNull { expr } => expr.convert_binary(col_id),
+            ScalarExpression::Unary { expr, .. } => expr.convert_binary(col_id),
+            _ => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::Bound;
+    use std::sync::Arc;
+    use crate::catalog::{ColumnCatalog, ColumnDesc};
+    use crate::expression::{BinaryOperator, ScalarExpression};
+    use crate::expression::index::IndexBinary;
+    use crate::types::errors::TypeError;
+    use crate::types::LogicalType;
+    use crate::types::value::DataValue;
+
+    fn build_test_expr() -> (ScalarExpression, ScalarExpression) {
+        let col_1 = Arc::new(ColumnCatalog {
+            id: 0,
+            name: "c1".to_string(),
+            table_name: None,
+            nullable: false,
+            desc: ColumnDesc {
+                column_datatype: LogicalType::Integer,
+                is_primary: false,
+                is_unique: false,
+            },
+        });
+
+        let c1_main_binary_expr = ScalarExpression::Binary {
+            op: BinaryOperator::Minus,
+            left_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            right_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(1))))),
+            ty: LogicalType::Integer,
+        };
+        let val_main_binary_expr = ScalarExpression::Binary {
+            op: BinaryOperator::Minus,
+            left_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(1))))),
+            right_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            ty: LogicalType::Integer,
+        };
+
+        let comparison_expr_op = |expr| {
+            ScalarExpression::Binary {
+                op: BinaryOperator::GtEq,
+                left_expr: Box::new(ScalarExpression::Alias {
+                    expr: Box::from(expr),
+                    alias: "alias".to_string(),
+                }),
+                right_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(2))))),
+                ty: LogicalType::Boolean,
+            }
+        };
+        // c1 - 1 >= 2
+        let c1_main_expr = comparison_expr_op(c1_main_binary_expr);
+        // 1 - c1 >= 2
+        let val_main_expr = comparison_expr_op(val_main_binary_expr);
+
+        (c1_main_expr, val_main_expr)
+    }
+
+    #[test]
+    fn test_convert_binary_simple() -> Result<(), TypeError> {
+        let col_1 = Arc::new(ColumnCatalog {
+            id: 0,
+            name: "c1".to_string(),
+            table_name: None,
+            nullable: false,
+            desc: ColumnDesc {
+                column_datatype: LogicalType::Integer,
+                is_primary: false,
+                is_unique: false,
+            },
+        });
+        let val_1 = Arc::new(DataValue::Int32(Some(1)));
+
+        let binary_eq = ScalarExpression::Binary {
+            op: BinaryOperator::Eq,
+            left_expr: Box::new(ScalarExpression::Constant(val_1.clone())),
+            right_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            ty: LogicalType::Boolean,
+        }.convert_binary(&0)?.unwrap();
+
+        assert_eq!(binary_eq, IndexBinary::Eq(val_1.clone()));
+
+        let binary_not_eq = ScalarExpression::Binary {
+            op: BinaryOperator::NotEq,
+            left_expr: Box::new(ScalarExpression::Constant(val_1.clone())),
+            right_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            ty: LogicalType::Boolean,
+        }.convert_binary(&0)?.unwrap();
+
+        assert_eq!(binary_not_eq, IndexBinary::NotEq(val_1.clone()));
+
+        let binary_lt = ScalarExpression::Binary {
+            op: BinaryOperator::Lt,
+            left_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            right_expr: Box::new(ScalarExpression::Constant(val_1.clone())),
+            ty: LogicalType::Boolean,
+        }.convert_binary(&0)?.unwrap();
+
+        assert_eq!(binary_lt, IndexBinary::Scope {
+            min: Bound::Unbounded,
+            max: Bound::Excluded(val_1.clone())
+        });
+
+        let binary_lteq = ScalarExpression::Binary {
+            op: BinaryOperator::LtEq,
+            left_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            right_expr: Box::new(ScalarExpression::Constant(val_1.clone())),
+            ty: LogicalType::Boolean,
+        }.convert_binary(&0)?.unwrap();
+
+        assert_eq!(binary_lteq, IndexBinary::Scope {
+            min: Bound::Unbounded,
+            max: Bound::Included(val_1.clone())
+        });
+
+        let binary_gt = ScalarExpression::Binary {
+            op: BinaryOperator::Gt,
+            left_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            right_expr: Box::new(ScalarExpression::Constant(val_1.clone())),
+            ty: LogicalType::Boolean,
+        }.convert_binary(&0)?.unwrap();
+
+        assert_eq!(binary_gt, IndexBinary::Scope {
+            min: Bound::Excluded(val_1.clone()),
+            max: Bound::Unbounded
+        });
+
+        let binary_gteq = ScalarExpression::Binary {
+            op: BinaryOperator::GtEq,
+            left_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
+            right_expr: Box::new(ScalarExpression::Constant(val_1.clone())),
+            ty: LogicalType::Boolean,
+        }.convert_binary(&0)?.unwrap();
+
+        assert_eq!(binary_gteq, IndexBinary::Scope {
+            min: Bound::Included(val_1.clone()),
+            max: Bound::Unbounded
+        });
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_arithmetic_flip() {
+        let (mut c1_main_expr, mut val_main_expr) = build_test_expr();
+
+        // c1 - 1 >= 2
+        c1_main_expr.arithmetic_flip(&0, &mut None);
+        println!("{:#?}", c1_main_expr);
+
+        // 1 - c1 >= 2
+        val_main_expr.arithmetic_flip(&0, &mut None);
+        println!("{:#?}", val_main_expr);
+    }
+
+    #[test]
+    fn test_convert_binary_nested() -> Result<(), TypeError> {
+        let (mut c1_main_expr, mut val_main_expr) = build_test_expr();
+
+        // c1 - 1 >= 2
+        c1_main_expr.arithmetic_flip(&0, &mut None);
+        println!("{:#?}", c1_main_expr.convert_binary(&0)?);
+
+        // 1 - c1 >= 2
+        val_main_expr.arithmetic_flip(&0, &mut None);
+        println!("{:#?}", val_main_expr.convert_binary(&0)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scope_aggregation() {
+        let val_1 = Arc::new(DataValue::Int32(Some(0)));
+        let val_2 = Arc::new(DataValue::Int32(Some(1)));
+        let val_3 = Arc::new(DataValue::Int32(Some(2)));
+        let val_4 = Arc::new(DataValue::Int32(Some(3)));
+
+        let binaries = vec![
+            IndexBinary::Scope {
+                min: Bound::Excluded(val_1.clone()),
+                max: Bound::Included(val_4.clone())
+            },
+            IndexBinary::Scope {
+                min: Bound::Included(val_2.clone()),
+                max: Bound::Excluded(val_3.clone())
+            },
+            IndexBinary::Scope {
+                min: Bound::Excluded(val_2.clone()),
+                max: Bound::Included(val_3.clone())
+            },
+            IndexBinary::Scope {
+                min: Bound::Included(val_1.clone()),
+                max: Bound::Excluded(val_4.clone())
+            },
+            IndexBinary::Scope {
+                min: Bound::Unbounded,
+                max: Bound::Unbounded,
+            },
+            IndexBinary::Eq(val_1.clone()),
+        ];
+
+        assert_eq!(
+            IndexBinary::scope_aggregation(binaries).unwrap(),
+            vec![
+                IndexBinary::Eq(val_1.clone()),
+                IndexBinary::Scope {
+                    min: Bound::Excluded(val_2.clone()),
+                    max: Bound::Excluded(val_3.clone()),
+                }
+            ]
+        )
+    }
+}

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -258,8 +258,10 @@ pub enum BinaryOperator {
     Minus,
     Multiply,
     Divide,
+
     Modulo,
     StringConcat,
+
     Gt,
     Lt,
     GtEq,
@@ -267,6 +269,7 @@ pub enum BinaryOperator {
     Spaceship,
     Eq,
     NotEq,
+
     And,
     Or,
     Xor,

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -16,6 +16,7 @@ use crate::types::tuple::Tuple;
 pub mod agg;
 mod evaluator;
 pub mod value_compute;
+pub mod simplify;
 
 /// ScalarExpression represnet all scalar expression in SQL.
 /// SELECT a+1, b FROM t1.
@@ -36,7 +37,6 @@ pub enum ScalarExpression {
     TypeCast {
         expr: Box<ScalarExpression>,
         ty: LogicalType,
-        is_try: bool,
     },
     IsNull {
         expr: Box<ScalarExpression>,

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -173,14 +173,14 @@ impl ScalarExpression {
                 Arc::new(ColumnCatalog::new(
                     format!("{}", value),
                     true,
-                    ColumnDesc::new(value.logical_type(), false)
+                    ColumnDesc::new(value.logical_type(), false, false)
                 ))
             }
             ScalarExpression::Alias { expr, alias } => {
                 Arc::new(ColumnCatalog::new(
                     alias.to_string(),
                     true,
-                    ColumnDesc::new(expr.return_type(), false)
+                    ColumnDesc::new(expr.return_type(), false, false)
                 ))
             }
             ScalarExpression::AggCall { kind, args, ty, distinct } => {
@@ -204,7 +204,7 @@ impl ScalarExpression {
                 Arc::new(ColumnCatalog::new(
                     column_name,
                     true,
-                    ColumnDesc::new(ty.clone(), false)
+                    ColumnDesc::new(ty.clone(), false, false)
                 ))
             }
             ScalarExpression::InputRef { index, .. } => {
@@ -226,7 +226,7 @@ impl ScalarExpression {
                 Arc::new(ColumnCatalog::new(
                     column_name,
                     true,
-                    ColumnDesc::new(ty.clone(), false)
+                    ColumnDesc::new(ty.clone(), false, false)
                 ))
             }
             _ => unreachable!()

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -252,7 +252,7 @@ struct ReplaceUnary {
 }
 
 impl ScalarExpression {
-    fn unpack_val(&mut self) -> Option<ValueRef> {
+    fn unpack_val(&self) -> Option<ValueRef> {
         match self {
             ScalarExpression::Constant(val) => Some(val.clone()),
             ScalarExpression::Alias { expr, .. } => expr.unpack_val(),
@@ -279,15 +279,7 @@ impl ScalarExpression {
                 let right = right_expr.unpack_val()?;
 
                 binary_op(&left, &right, op).ok()
-                    .map(|val| {
-                        let val_ref = Arc::new(val);
-                        let _ = mem::replace(
-                            self,
-                            ScalarExpression::Constant(val_ref.clone()),
-                        );
-
-                        val_ref
-                    })
+                    .map(Arc::new)
             }
             _ => None
         }
@@ -496,7 +488,7 @@ impl ScalarExpression {
     /// The And and Or of ConstantBinary are concerned with the data range that needs to be aggregated.
     /// - `ConstantBinary::And`: Aggregate the minimum range of all conditions in and
     /// - `ConstantBinary::Or`: Rearrange and sort the range of each OR data
-    pub fn convert_binary(&mut self, col_id: &ColumnId) -> Result<Option<ConstantBinary>, TypeError> {
+    pub fn convert_binary(&self, col_id: &ColumnId) -> Result<Option<ConstantBinary>, TypeError> {
         match self {
             ScalarExpression::Binary { left_expr, right_expr, op, .. } => {
                 match (left_expr.convert_binary(col_id)?, right_expr.convert_binary(col_id)?) {

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -27,6 +27,7 @@ pub enum ConstantBinary {
 }
 
 impl ConstantBinary {
+    #[allow(dead_code)]
     fn is_null(&self) -> Result<bool, TypeError> {
         match self {
             ConstantBinary::Scope { min, max } => {
@@ -50,7 +51,7 @@ impl ConstantBinary {
 
     pub fn rearrange(self) -> Result<Vec<ConstantBinary>, TypeError> {
         match self {
-            ConstantBinary::Or(mut binaries) => {
+            ConstantBinary::Or(binaries) => {
                 let mut condition_binaries = Vec::new();
 
                 for binary in binaries {
@@ -622,51 +623,6 @@ mod test {
     use crate::types::errors::TypeError;
     use crate::types::LogicalType;
     use crate::types::value::DataValue;
-
-    fn build_test_expr() -> (ScalarExpression, ScalarExpression) {
-        let col_1 = Arc::new(ColumnCatalog {
-            id: Some(0),
-            name: "c1".to_string(),
-            table_name: None,
-            nullable: false,
-            desc: ColumnDesc {
-                column_datatype: LogicalType::Integer,
-                is_primary: false,
-                is_unique: false,
-            },
-        });
-
-        let c1_main_binary_expr = ScalarExpression::Binary {
-            op: BinaryOperator::Minus,
-            left_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
-            right_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(1))))),
-            ty: LogicalType::Integer,
-        };
-        let val_main_binary_expr = ScalarExpression::Binary {
-            op: BinaryOperator::Minus,
-            left_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(1))))),
-            right_expr: Box::new(ScalarExpression::ColumnRef(col_1.clone())),
-            ty: LogicalType::Integer,
-        };
-
-        let comparison_expr_op = |expr| {
-            ScalarExpression::Binary {
-                op: BinaryOperator::GtEq,
-                left_expr: Box::new(ScalarExpression::Alias {
-                    expr: Box::from(expr),
-                    alias: "alias".to_string(),
-                }),
-                right_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(2))))),
-                ty: LogicalType::Boolean,
-            }
-        };
-        // c1 - 1 >= 2
-        let c1_main_expr = comparison_expr_op(c1_main_binary_expr);
-        // 1 - c1 >= 2
-        let val_main_expr = comparison_expr_op(val_main_binary_expr);
-
-        (c1_main_expr, val_main_expr)
-    }
 
     #[test]
     fn test_convert_binary_simple() -> Result<(), TypeError> {

--- a/src/expression/value_compute.rs
+++ b/src/expression/value_compute.rs
@@ -1184,7 +1184,7 @@ mod test {
     }
     
     #[test]
-    fn test_binary_op_Utf8_compare()->Result<(),TypeError>{
+    fn test_binary_op_utf8_compare()->Result<(),TypeError>{
         assert_eq!(binary_op(&DataValue::Utf8(Some("a".to_string())), &DataValue::Utf8(Some("b".to_string())), &BinaryOperator::Gt)?, DataValue::Boolean(Some(false)));
         assert_eq!(binary_op(&DataValue::Utf8(Some("a".to_string())), &DataValue::Utf8(Some("b".to_string())), &BinaryOperator::Lt)?, DataValue::Boolean(Some(true)));
         assert_eq!(binary_op(&DataValue::Utf8(Some("a".to_string())), &DataValue::Utf8(Some("a".to_string())), &BinaryOperator::GtEq)?, DataValue::Boolean(Some(true)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(generators)]
 #![feature(iterator_try_collect)]
 #![feature(slice_pattern)]
+#![feature(bound_map)]
 extern crate core;
 
 pub mod binder;

--- a/src/optimizer/core/rule.rs
+++ b/src/optimizer/core/rule.rs
@@ -1,10 +1,11 @@
 use crate::optimizer::core::pattern::Pattern;
 use crate::optimizer::heuristic::graph::{HepGraph, HepNodeId};
+use crate::optimizer::OptimizerError;
 
 /// A rule is to transform logically equivalent expression
 pub trait Rule {
     /// The pattern to determine whether the rule can be applied.
     fn pattern(&self) -> &Pattern;
 
-    fn apply(&self, node_id: HepNodeId, graph: &mut HepGraph);
+    fn apply(&self, node_id: HepNodeId, graph: &mut HepGraph) -> Result<(), OptimizerError>;
 }

--- a/src/optimizer/heuristic/optimizer.rs
+++ b/src/optimizer/heuristic/optimizer.rs
@@ -3,6 +3,7 @@ use crate::optimizer::core::rule::Rule;
 use crate::optimizer::heuristic::batch::{HepBatch, HepBatchStrategy};
 use crate::optimizer::heuristic::graph::{HepGraph, HepNodeId};
 use crate::optimizer::heuristic::matcher::HepMatcher;
+use crate::optimizer::OptimizerError;
 use crate::optimizer::rule::RuleImpl;
 use crate::planner::LogicalPlan;
 
@@ -24,7 +25,7 @@ impl HepOptimizer {
         self
     }
 
-    pub fn find_best(&mut self) -> LogicalPlan {
+    pub fn find_best(&mut self) -> Result<LogicalPlan, OptimizerError> {
         let batches = self.batches.clone();
 
         for batch in batches {
@@ -32,7 +33,7 @@ impl HepOptimizer {
             let mut iteration = 1usize;
 
             while iteration <= batch.strategy.max_iteration && !batch_over {
-                if self.apply_batch(&batch) {
+                if self.apply_batch(&batch)? {
                     iteration += 1;
                 } else {
                     batch_over = true
@@ -40,31 +41,31 @@ impl HepOptimizer {
             }
         }
 
-        self.graph.to_plan()
+        Ok(self.graph.to_plan())
     }
 
-    fn apply_batch(&mut self, HepBatch{ rules, strategy, .. }: &HepBatch) -> bool {
+    fn apply_batch(&mut self, HepBatch{ rules, strategy, .. }: &HepBatch) -> Result<bool, OptimizerError> {
         let start_ver = self.graph.version;
 
         for rule in rules {
             for node_id in self.graph.nodes_iter(strategy.match_order, None) {
-                if self.apply_rule(rule, node_id) {
+                if self.apply_rule(rule, node_id)? {
                     break;
                 }
             }
         }
 
-        start_ver != self.graph.version
+        Ok(start_ver != self.graph.version)
     }
 
-    fn apply_rule(&mut self, rule: &RuleImpl, node_id: HepNodeId) -> bool {
+    fn apply_rule(&mut self, rule: &RuleImpl, node_id: HepNodeId) -> Result<bool, OptimizerError> {
         let after_version = self.graph.version;
 
         if HepMatcher::new(rule.pattern(), node_id, &self.graph).match_opt_expr() {
-            rule.apply(node_id, &mut self.graph);
+            rule.apply(node_id, &mut self.graph)?;
         }
 
-        after_version != self.graph.version
+        Ok(after_version != self.graph.version)
     }
 
 }

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -1,6 +1,18 @@
+use crate::types::errors::TypeError;
+
 /// The architecture and some components,
 /// such as (/core) are referenced from sqlrs
 
 mod core;
 pub mod heuristic;
 pub mod rule;
+
+#[derive(thiserror::Error, Debug)]
+pub enum OptimizerError {
+    #[error("type error")]
+    TypeError(
+        #[source]
+        #[from]
+        TypeError
+    )
+}

--- a/src/optimizer/rule/column_pruning.rs
+++ b/src/optimizer/rule/column_pruning.rs
@@ -105,6 +105,7 @@ impl Rule for PushProjectThroughChild {
                         .iter()
                         .map(|col| col.id)
                 )
+                .flatten()
                 .collect::<HashSet<ColumnId>>();
 
             if intersection_columns_ids.is_empty() {
@@ -116,7 +117,10 @@ impl Rule for PushProjectThroughChild {
                     .referenced_columns()
                     .into_iter()
                     .unique_by(|col| col.id)
-                    .filter(|u| intersection_columns_ids.contains(&u.id))
+                    .filter(|u| matches!(
+                            u.id.map(|u_id| intersection_columns_ids.contains(&u_id)),
+                            Some(true)
+                        ))
                     .map(|col| ScalarExpression::ColumnRef(col))
                     .collect_vec();
 

--- a/src/optimizer/rule/mod.rs
+++ b/src/optimizer/rule/mod.rs
@@ -7,6 +7,7 @@ use crate::optimizer::rule::column_pruning::{PushProjectIntoScan, PushProjectThr
 use crate::optimizer::rule::combine_operators::{CollapseProject, CombineFilter};
 use crate::optimizer::rule::pushdown_limit::{LimitProjectTranspose, EliminateLimits, PushLimitThroughJoin, PushLimitIntoScan};
 use crate::optimizer::rule::pushdown_predicates::PushPredicateThroughJoin;
+use crate::optimizer::rule::pushdown_predicates::PushPredicateIntoScan;
 use crate::optimizer::rule::simplification::SimplifyFilter;
 
 mod column_pruning;
@@ -30,6 +31,8 @@ pub enum RuleImpl {
     PushLimitIntoTableScan,
     // PushDown predicates
     PushPredicateThroughJoin,
+    // Tips: need to be used with `SimplifyFilter`
+    PushPredicateIntoScan,
     // Simplification
     SimplifyFilter
 }
@@ -46,6 +49,7 @@ impl Rule for RuleImpl {
             RuleImpl::PushLimitThroughJoin => PushLimitThroughJoin {}.pattern(),
             RuleImpl::PushLimitIntoTableScan => PushLimitIntoScan {}.pattern(),
             RuleImpl::PushPredicateThroughJoin => PushPredicateThroughJoin {}.pattern(),
+            RuleImpl::PushPredicateIntoScan => PushPredicateIntoScan {}.pattern(),
             RuleImpl::SimplifyFilter => SimplifyFilter {}.pattern(),
         }
     }
@@ -61,7 +65,8 @@ impl Rule for RuleImpl {
             RuleImpl::PushLimitThroughJoin => PushLimitThroughJoin {}.apply(node_id, graph),
             RuleImpl::PushLimitIntoTableScan => PushLimitIntoScan {}.apply(node_id, graph),
             RuleImpl::PushPredicateThroughJoin => PushPredicateThroughJoin {}.apply(node_id, graph),
-            RuleImpl::SimplifyFilter => SimplifyFilter {}.apply(node_id, graph)
+            RuleImpl::SimplifyFilter => SimplifyFilter {}.apply(node_id, graph),
+            RuleImpl::PushPredicateIntoScan => PushPredicateIntoScan {}.apply(node_id, graph)
         }
     }
 }

--- a/src/optimizer/rule/pushdown_predicates.rs
+++ b/src/optimizer/rule/pushdown_predicates.rs
@@ -233,20 +233,23 @@ impl Rule for PushPredicateIntoScan {
 
                     if let Some(mut binary) = option.take() {
                         binary.scope_aggregation()?;
-                        let mut scan_by_index = child_op.clone();
+                        let rearrange_binaries = binary.rearrange()?;
 
-                        scan_by_index.index_by = Some((meta.clone(), binary.rearrange()?));
+                        if !rearrange_binaries.is_empty() {
+                            let mut scan_by_index = child_op.clone();
+                            scan_by_index.index_by = Some((meta.clone(), rearrange_binaries));
 
-                        // The constant expression extracted in prewhere is used to
-                        // reduce the data scanning range and cannot replace the role of Filter.
-                        graph.replace_node(
-                            child_id,
-                            OptExprNode::OperatorRef(
-                                Operator::Scan(scan_by_index)
-                            )
-                        );
+                            // The constant expression extracted in prewhere is used to
+                            // reduce the data scanning range and cannot replace the role of Filter.
+                            graph.replace_node(
+                                child_id,
+                                OptExprNode::OperatorRef(
+                                    Operator::Scan(scan_by_index)
+                                )
+                            );
 
-                        return Ok(())
+                            return Ok(())
+                        }
                     }
                 }
             }

--- a/src/optimizer/rule/simplification.rs
+++ b/src/optimizer/rule/simplification.rs
@@ -255,4 +255,35 @@ mod test {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_simplify_filter_multiple_column_in_or() -> Result<(), DatabaseError> {
+        // c1 + 1 < -1 => c1 < -2
+        let plan_1 = select_sql_run("select * from t1 where c1 > c2 or c1 > 1").await?;
+
+        let op = |plan: LogicalPlan, expr: &str| -> Result<Option<FilterOperator>, DatabaseError> {
+            let best_plan = HepOptimizer::new(plan.clone())
+                .batch(
+                    "test_simplify_filter".to_string(),
+                    HepBatchStrategy::once_topdown(),
+                    vec![RuleImpl::SimplifyFilter]
+                )
+                .find_best()?;
+            if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
+                println!("{expr}: {:#?}", filter_op);
+
+                Ok(Some(filter_op))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let op_1 = op(plan_1, "c1 > c2 or c1 > 1")?.unwrap();
+
+        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        println!("op_1 => c1: {:#?}", cb_1_c1);
+        assert_eq!(cb_1_c1, None);
+
+        Ok(())
+    }
 }

--- a/src/optimizer/rule/simplification.rs
+++ b/src/optimizer/rule/simplification.rs
@@ -38,29 +38,36 @@ impl Rule for SimplifyFilter {
 
 #[cfg(test)]
 mod test {
+    use std::collections::Bound;
+    use std::sync::Arc;
     use crate::binder::test::select_sql_run;
+    use crate::catalog::{ColumnCatalog, ColumnDesc};
     use crate::db::DatabaseError;
+    use crate::expression::{BinaryOperator, ScalarExpression, UnaryOperator};
     use crate::expression::simplify::ConstantBinary;
     use crate::optimizer::heuristic::batch::HepBatchStrategy;
     use crate::optimizer::heuristic::optimizer::HepOptimizer;
     use crate::optimizer::rule::RuleImpl;
     use crate::planner::LogicalPlan;
+    use crate::planner::operator::filter::FilterOperator;
     use crate::planner::operator::Operator;
+    use crate::types::LogicalType;
+    use crate::types::value::DataValue;
 
     #[tokio::test]
-    async fn test_simplify_filter() -> Result<(), DatabaseError> {
-        // c1 + 1 < -1 -> c1 < -2
+    async fn test_simplify_filter_single_column() -> Result<(), DatabaseError> {
+        // c1 + 1 < -1 => c1 < -2
         let plan_1 = select_sql_run("select * from t1 where -(c1 + 1) > 1").await?;
-        // 1 - c1 < -1 -> c1 > 2
+        // 1 - c1 < -1 => c1 > 2
         let plan_2 = select_sql_run("select * from t1 where -(1 - c1) > 1").await?;
         // c1 < -1
         let plan_3 = select_sql_run("select * from t1 where -c1 > 1").await?;
         // c1 > 0
         let plan_4 = select_sql_run("select * from t1 where c1 + 1 > 1").await?;
 
-        // c1 + 1 < -1 -> c1 < -2
+        // c1 + 1 < -1 => c1 < -2
         let plan_5 = select_sql_run("select * from t1 where 1 < -(c1 + 1)").await?;
-        // 1 - c1 < -1 -> c1 > 2
+        // 1 - c1 < -1 => c1 > 2
         let plan_6 = select_sql_run("select * from t1 where 1 < -(1 - c1)").await?;
         // c1 < -1
         let plan_7 = select_sql_run("select * from t1 where 1 < -c1").await?;
@@ -88,6 +95,167 @@ mod test {
         assert_eq!(op(plan_2, "-(1 - c1) > 1")?, op(plan_6, "1 < -(1 - c1)")?);
         assert_eq!(op(plan_3, "-c1 > 1")?, op(plan_7, "1 < -c1")?);
         assert_eq!(op(plan_4, "c1 + 1 > 1")?, op(plan_8, "1 < c1 + 1")?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_simplify_filter_repeating_column() -> Result<(), DatabaseError> {
+        let plan = select_sql_run("select * from t1 where -(c1 + 1) > c2").await?;
+
+        let best_plan = HepOptimizer::new(plan.clone())
+            .batch(
+                "test_simplify_filter".to_string(),
+                HepBatchStrategy::once_topdown(),
+                vec![RuleImpl::SimplifyFilter]
+            )
+            .find_best()?;
+        if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
+            let c1_col = ColumnCatalog {
+                id: Some(
+                    0,
+                ),
+                name: "c1".to_string(),
+                table_name: Some(
+                    Arc::new("t1".to_string()),
+                ),
+                nullable: false,
+                desc: ColumnDesc {
+                    column_datatype: LogicalType::Integer,
+                    is_primary: true,
+                    is_unique: true,
+                },
+            };
+            let c2_col = ColumnCatalog {
+                id: Some(
+                    1,
+                ),
+                name: "c2".to_string(),
+                table_name: Some(
+                    Arc::new("t1".to_string()),
+                ),
+                nullable: false,
+                desc: ColumnDesc {
+                    column_datatype: LogicalType::Integer,
+                    is_primary: false,
+                    is_unique: false,
+                },
+            };
+
+            // -(c1 + 1) > c2 => c1 < -c2 - 1
+            assert_eq!(
+                filter_op.predicate,
+                ScalarExpression::Binary {
+                    op: BinaryOperator::Lt,
+                    left_expr: Box::new(ScalarExpression::ColumnRef(Arc::new(c1_col))),
+                    right_expr: Box::new(ScalarExpression::Binary {
+                        op: BinaryOperator::Minus,
+                        left_expr: Box::new(ScalarExpression::Unary {
+                            op: UnaryOperator::Minus,
+                            expr: Box::new(ScalarExpression::ColumnRef(Arc::new(c2_col))),
+                            ty: LogicalType::Integer,
+                        }),
+                        right_expr: Box::new(ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(1))))),
+                        ty: LogicalType::Integer,
+                    }),
+                    ty: LogicalType::Boolean,
+                }
+            )
+        } else {
+            unreachable!()
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_simplify_filter_multiple_column() -> Result<(), DatabaseError> {
+        // c1 + 1 < -1 => c1 < -2
+        let plan_1 = select_sql_run("select * from t1 where -(c1 + 1) > 1 and -(1 - c2) > 1").await?;
+        // 1 - c1 < -1 => c1 > 2
+        let plan_2 = select_sql_run("select * from t1 where -(1 - c1) > 1 and -(c2 + 1) > 1").await?;
+        // c1 < -1
+        let plan_3 = select_sql_run("select * from t1 where -c1 > 1 and c2 + 1 > 1").await?;
+        // c1 > 0
+        let plan_4 = select_sql_run("select * from t1 where c1 + 1 > 1 and -c2 > 1").await?;
+
+        let op = |plan: LogicalPlan, expr: &str| -> Result<Option<FilterOperator>, DatabaseError> {
+            let best_plan = HepOptimizer::new(plan.clone())
+                .batch(
+                    "test_simplify_filter".to_string(),
+                    HepBatchStrategy::once_topdown(),
+                    vec![RuleImpl::SimplifyFilter]
+                )
+                .find_best()?;
+            if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
+                println!("{expr}: {:#?}", filter_op);
+
+                Ok(Some(filter_op))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let op_1 = op(plan_1, "-(c1 + 1) > 1 and -(1 - c2) > 1")?.unwrap();
+        let op_2 = op(plan_2, "-(1 - c1) > 1 and -(c2 + 1) > 1")?.unwrap();
+        let op_3 = op(plan_3, "-c1 > 1 and c2 + 1 > 1")?.unwrap();
+        let op_4 = op(plan_4, "c1 + 1 > 1 and -c2 > 1")?.unwrap();
+
+        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        println!("op_1 => c1: {:#?}", cb_1_c1);
+        assert_eq!(cb_1_c1, Some(ConstantBinary::Scope {
+            min: Bound::Unbounded,
+            max: Bound::Excluded(Arc::new(DataValue::Int32(Some(-2))))
+        }));
+
+        let cb_1_c2 = op_1.predicate.convert_binary(&1).unwrap();
+        println!("op_1 => c2: {:#?}", cb_1_c2);
+        assert_eq!(cb_1_c2, Some(ConstantBinary::Scope {
+            min: Bound::Excluded(Arc::new(DataValue::Int32(Some(2)))),
+            max: Bound::Unbounded
+        }));
+
+        let cb_2_c1 = op_2.predicate.convert_binary(&0).unwrap();
+        println!("op_2 => c1: {:#?}", cb_2_c1);
+        assert_eq!(cb_2_c1, Some(ConstantBinary::Scope {
+            min: Bound::Excluded(Arc::new(DataValue::Int32(Some(2)))),
+            max: Bound::Unbounded
+        }));
+
+        let cb_2_c2 = op_2.predicate.convert_binary(&1).unwrap();
+        println!("op_2 => c2: {:#?}", cb_2_c2);
+        assert_eq!(cb_1_c1, Some(ConstantBinary::Scope {
+            min: Bound::Unbounded,
+            max: Bound::Excluded(Arc::new(DataValue::Int32(Some(-2))))
+        }));
+
+        let cb_3_c1 = op_3.predicate.convert_binary(&0).unwrap();
+        println!("op_3 => c1: {:#?}", cb_3_c1);
+        assert_eq!(cb_3_c1, Some(ConstantBinary::Scope {
+            min: Bound::Unbounded,
+            max: Bound::Excluded(Arc::new(DataValue::Int32(Some(-1))))
+        }));
+
+        let cb_3_c2 = op_3.predicate.convert_binary(&1).unwrap();
+        println!("op_3 => c2: {:#?}", cb_3_c2);
+        assert_eq!(cb_3_c2, Some(ConstantBinary::Scope {
+            min: Bound::Excluded(Arc::new(DataValue::Int32(Some(0)))),
+            max: Bound::Unbounded
+        }));
+
+        let cb_4_c1 = op_4.predicate.convert_binary(&0).unwrap();
+        println!("op_4 => c1: {:#?}", cb_4_c1);
+        assert_eq!(cb_4_c1, Some(ConstantBinary::Scope {
+            min: Bound::Excluded(Arc::new(DataValue::Int32(Some(0)))),
+            max: Bound::Unbounded
+        }));
+
+        let cb_4_c2 = op_4.predicate.convert_binary(&1).unwrap();
+        println!("op_4 => c2: {:#?}", cb_4_c2);
+        assert_eq!(cb_4_c2, Some(ConstantBinary::Scope {
+            min: Bound::Unbounded,
+            max: Bound::Excluded(Arc::new(DataValue::Int32(Some(-1))))
+        }));
 
         Ok(())
     }

--- a/src/optimizer/rule/simplification.rs
+++ b/src/optimizer/rule/simplification.rs
@@ -1,0 +1,94 @@
+use lazy_static::lazy_static;
+use crate::optimizer::core::opt_expr::OptExprNode;
+use crate::optimizer::core::pattern::{Pattern, PatternChildrenPredicate};
+use crate::optimizer::core::rule::Rule;
+use crate::optimizer::heuristic::graph::{HepGraph, HepNodeId};
+use crate::optimizer::OptimizerError;
+use crate::planner::operator::Operator;
+lazy_static! {
+    static ref SIMPLIFY_FILTER_RULE: Pattern = {
+        Pattern {
+            predicate: |op| matches!(op, Operator::Filter(_)),
+            children: PatternChildrenPredicate::None,
+        }
+    };
+}
+
+#[derive(Copy, Clone)]
+pub struct SimplifyFilter;
+
+impl Rule for SimplifyFilter {
+    fn pattern(&self) -> &Pattern {
+        &SIMPLIFY_FILTER_RULE
+    }
+
+    fn apply(&self, node_id: HepNodeId, graph: &mut HepGraph) -> Result<(), OptimizerError> {
+        if let Operator::Filter(mut filter_op) = graph.operator(node_id).clone() {
+            filter_op.predicate.simplify()?;
+
+            graph.replace_node(
+                node_id,
+                OptExprNode::OperatorRef(Operator::Filter(filter_op))
+            )
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::binder::test::select_sql_run;
+    use crate::db::DatabaseError;
+    use crate::expression::simplify::ConstantBinary;
+    use crate::optimizer::heuristic::batch::HepBatchStrategy;
+    use crate::optimizer::heuristic::optimizer::HepOptimizer;
+    use crate::optimizer::rule::RuleImpl;
+    use crate::planner::LogicalPlan;
+    use crate::planner::operator::Operator;
+
+    #[tokio::test]
+    async fn test_simplify_filter() -> Result<(), DatabaseError> {
+        // c1 + 1 < -1 -> c1 < -2
+        let plan_1 = select_sql_run("select * from t1 where -(c1 + 1) > 1").await?;
+        // 1 - c1 < -1 -> c1 > 2
+        let plan_2 = select_sql_run("select * from t1 where -(1 - c1) > 1").await?;
+        // c1 < -1
+        let plan_3 = select_sql_run("select * from t1 where -c1 > 1").await?;
+        // c1 > 0
+        let plan_4 = select_sql_run("select * from t1 where c1 + 1 > 1").await?;
+
+        // c1 + 1 < -1 -> c1 < -2
+        let plan_5 = select_sql_run("select * from t1 where 1 < -(c1 + 1)").await?;
+        // 1 - c1 < -1 -> c1 > 2
+        let plan_6 = select_sql_run("select * from t1 where 1 < -(1 - c1)").await?;
+        // c1 < -1
+        let plan_7 = select_sql_run("select * from t1 where 1 < -c1").await?;
+        // c1 > 0
+        let plan_8 = select_sql_run("select * from t1 where 1 < c1 + 1").await?;
+
+        let op = |plan: LogicalPlan, expr: &str| -> Result<Option<ConstantBinary>, DatabaseError> {
+            let best_plan = HepOptimizer::new(plan.clone())
+                .batch(
+                    "test_simplify_filter".to_string(),
+                    HepBatchStrategy::once_topdown(),
+                    vec![RuleImpl::SimplifyFilter]
+                )
+                .find_best()?;
+            if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
+                println!("{expr}: {:#?}", filter_op.predicate.convert_binary(&0).unwrap());
+
+                Ok(filter_op.predicate.convert_binary(&0).unwrap())
+            } else {
+                Ok(None)
+            }
+        };
+
+        assert_eq!(op(plan_1, "-(c1 + 1) > 1")?, op(plan_5, "1 < -(c1 + 1)")?);
+        assert_eq!(op(plan_2, "-(1 - c1) > 1")?, op(plan_6, "1 < -(1 - c1)")?);
+        assert_eq!(op(plan_3, "-c1 > 1")?, op(plan_7, "1 < -c1")?);
+        assert_eq!(op(plan_4, "c1 + 1 > 1")?, op(plan_8, "1 < c1 + 1")?);
+
+        Ok(())
+    }
+}

--- a/src/optimizer/rule/simplification.rs
+++ b/src/optimizer/rule/simplification.rs
@@ -123,7 +123,7 @@ mod test {
                 desc: ColumnDesc {
                     column_datatype: LogicalType::Integer,
                     is_primary: true,
-                    is_unique: true,
+                    is_unique: false,
                 },
             };
             let c2_col = ColumnCatalog {
@@ -138,7 +138,7 @@ mod test {
                 desc: ColumnDesc {
                     column_datatype: LogicalType::Integer,
                     is_primary: false,
-                    is_unique: false,
+                    is_unique: true,
                 },
             };
 

--- a/src/optimizer/rule/simplification.rs
+++ b/src/optimizer/rule/simplification.rs
@@ -82,7 +82,7 @@ mod test {
                     vec![RuleImpl::SimplifyFilter]
                 )
                 .find_best()?;
-            if let Operator::Filter(mut filter_op) = best_plan.childrens[0].clone().operator {
+            if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
                 println!("{expr}: {:#?}", filter_op.predicate.convert_binary(&0).unwrap());
 
                 Ok(filter_op.predicate.convert_binary(&0).unwrap())
@@ -192,10 +192,10 @@ mod test {
             }
         };
 
-        let mut op_1 = op(plan_1, "-(c1 + 1) > 1 and -(1 - c2) > 1")?.unwrap();
-        let mut op_2 = op(plan_2, "-(1 - c1) > 1 and -(c2 + 1) > 1")?.unwrap();
-        let mut op_3 = op(plan_3, "-c1 > 1 and c2 + 1 > 1")?.unwrap();
-        let mut op_4 = op(plan_4, "c1 + 1 > 1 and -c2 > 1")?.unwrap();
+        let op_1 = op(plan_1, "-(c1 + 1) > 1 and -(1 - c2) > 1")?.unwrap();
+        let op_2 = op(plan_2, "-(1 - c1) > 1 and -(c2 + 1) > 1")?.unwrap();
+        let op_3 = op(plan_3, "-c1 > 1 and c2 + 1 > 1")?.unwrap();
+        let op_4 = op(plan_4, "c1 + 1 > 1 and -c2 > 1")?.unwrap();
 
         let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);

--- a/src/planner/operator/mod.rs
+++ b/src/planner/operator/mod.rs
@@ -125,11 +125,7 @@ impl Operator {
                     .collect_vec()
             }
             Operator::Scan(op) => {
-                op.sort_fields
-                    .iter()
-                    .map(|field| &field.expr)
-                    .chain(op.columns.iter())
-                    .chain(op.pre_where.iter())
+                op.columns.iter()
                     .flat_map(|expr| expr.referenced_columns())
                     .collect_vec()
             }

--- a/src/planner/operator/scan.rs
+++ b/src/planner/operator/scan.rs
@@ -4,13 +4,13 @@ use crate::expression::ScalarExpression;
 use crate::expression::simplify::ConstantBinary;
 use crate::planner::LogicalPlan;
 use crate::storage::Bounds;
-use crate::types::index::IndexRef;
+use crate::types::index::IndexMetaRef;
 
 use super::Operator;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ScanOperator {
-    pub index_metas: Vec<IndexRef>,
+    pub index_metas: Vec<IndexMetaRef>,
 
     pub table_name: TableName,
     pub columns: Vec<ScalarExpression>,
@@ -20,7 +20,7 @@ pub struct ScanOperator {
     // IndexScan only
     // Support push down predicate.
     // If pre_where is simple predicate, for example:  a > 1 then can calculate directly when read data.
-    pub index_by: Option<(IndexRef, Vec<ConstantBinary>)>,
+    pub index_by: Option<(IndexMetaRef, Vec<ConstantBinary>)>,
 }
 impl ScanOperator {
     pub fn new(table_name: TableName, table_catalog: &TableCatalog) -> LogicalPlan {

--- a/src/planner/operator/scan.rs
+++ b/src/planner/operator/scan.rs
@@ -1,24 +1,26 @@
 use itertools::Itertools;
 use crate::catalog::{TableCatalog, TableName};
 use crate::expression::ScalarExpression;
+use crate::expression::simplify::ConstantBinary;
 use crate::planner::LogicalPlan;
 use crate::storage::Bounds;
+use crate::types::index::IndexRef;
 
-use super::{sort::SortField, Operator};
+use super::Operator;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ScanOperator {
+    pub index_metas: Vec<IndexRef>,
+
     pub table_name: TableName,
     pub columns: Vec<ScalarExpression>,
     // Support push down limit.
     pub limit: Bounds,
 
     // IndexScan only
-    pub sort_fields: Vec<SortField>,
-    // IndexScan only
     // Support push down predicate.
     // If pre_where is simple predicate, for example:  a > 1 then can calculate directly when read data.
-    pub pre_where: Vec<ScalarExpression>,
+    pub index_by: Option<(IndexRef, Vec<ConstantBinary>)>,
 }
 impl ScanOperator {
     pub fn new(table_name: TableName, table_catalog: &TableCatalog) -> LogicalPlan {
@@ -31,11 +33,12 @@ impl ScanOperator {
 
         LogicalPlan {
             operator: Operator::Scan(ScanOperator {
+                index_metas: table_catalog.indexes.clone(),
                 table_name,
                 columns,
-                sort_fields: vec![],
-                pre_where: vec![],
+
                 limit: (None, None),
+                index_by: None,
             }),
             childrens: vec![],
         }

--- a/src/storage/kip.rs
+++ b/src/storage/kip.rs
@@ -261,7 +261,7 @@ impl Transaction for KipTransaction {
 
     fn read_by_index(
         &self,
-        (mut offset_option, mut limit_option): Bounds,
+        (offset_option, mut limit_option): Bounds,
         projections: Projections,
         index_meta: IndexMetaRef,
         binaries: Vec<ConstantBinary>

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -117,7 +117,7 @@ impl Storage for MemStorage {
         }
     }
 
-    async fn show_tables(&self) -> Option<Vec<(String, usize)>> {
+    async fn show_tables(&self) -> Result<Vec<String>, StorageError> {
         todo!()
     }
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -282,12 +282,12 @@ pub(crate) mod test {
             Arc::new(ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true)
+                ColumnDesc::new(LogicalType::Integer, true, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c2".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Boolean, false)
+                ColumnDesc::new(LogicalType::Boolean, false, false)
             )),
         ];
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use crate::catalog::{ColumnCatalog, RootCatalog, TableCatalog, TableName};
 use crate::storage::{Bounds, Projections, Storage, StorageError, Table, Transaction};
+use crate::types::index::Index;
 use crate::types::tuple::{Tuple, TupleId};
 
 // WARRING: Only single-threaded and tested using
@@ -158,6 +159,10 @@ impl Table for MemTable {
                 }
             )
         }
+    }
+
+    fn add_index(&mut self, _index: Index, _is_unique: bool) -> Result<(), StorageError> {
+        todo!()
     }
 
     fn append(&mut self, tuple: Tuple, is_overwrite: bool) -> Result<(), StorageError> {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -161,7 +161,11 @@ impl Table for MemTable {
         }
     }
 
-    fn add_index(&mut self, _index: Index, _is_unique: bool) -> Result<(), StorageError> {
+    fn add_index(&mut self, index: Index, tuple_ids: Vec<TupleId>, is_unique: bool) -> Result<(), StorageError> {
+        todo!()
+    }
+
+    fn del_index(&mut self, _index: &Index) -> Result<(), StorageError> {
         todo!()
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -145,10 +145,6 @@ pub enum StorageError {
 
     #[error("The column has been declared unique and the value already exists")]
     DuplicateUniqueValue,
-
-    #[error("Serialization error")]
-    Serialization,
-
 }
 
 impl From<KernelError> for StorageError {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -47,7 +47,9 @@ pub trait Table: Sync + Send + 'static {
         projection: Projections,
     ) -> Result<Self::TransactionType<'_>, StorageError>;
 
-    fn add_index(&mut self, index: Index, is_unique: bool) -> Result<(), StorageError>;
+    fn add_index(&mut self, index: Index, tuple_ids: Vec<TupleId>, is_unique: bool) -> Result<(), StorageError>;
+
+    fn del_index(&mut self, index: &Index) -> Result<(), StorageError>;
 
     fn append(&mut self, tuple: Tuple, is_overwrite: bool) -> Result<(), StorageError>;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,6 +8,7 @@ use kip_db::KernelError;
 use crate::catalog::{CatalogError, ColumnCatalog, TableCatalog, TableName};
 use crate::expression::ScalarExpression;
 use crate::types::errors::TypeError;
+use crate::types::index::Index;
 use crate::types::tuple::{Tuple, TupleId};
 
 #[async_trait]
@@ -46,6 +47,8 @@ pub trait Table: Sync + Send + 'static {
         projection: Projections,
     ) -> Result<Self::TransactionType<'_>, StorageError>;
 
+    fn add_index(&mut self, index: Index, is_unique: bool) -> Result<(), StorageError>;
+
     fn append(&mut self, tuple: Tuple, is_overwrite: bool) -> Result<(), StorageError>;
 
     fn delete(&mut self, tuple_id: TupleId) -> Result<(), StorageError>;
@@ -73,6 +76,9 @@ pub enum StorageError {
 
     #[error("The same primary key data already exists")]
     DuplicatePrimaryKey,
+
+    #[error("The column has been declared unique and the value already exists")]
+    DuplicateUniqueValue,
 
     #[error("Serialization error")]
     Serialization,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,7 +32,7 @@ pub trait Storage: Sync + Send + Clone + 'static {
     async fn transaction(&self, name: &String) -> Option<Self::TransactionType>;
     async fn table(&self, name: &String) -> Option<&TableCatalog>;
 
-    async fn show_tables(&self) -> Option<Vec<(String,usize)>>;
+    async fn show_tables(&self) -> Result<Vec<String>, StorageError>;
 }
 
 /// Optional bounds of the reader, of the form (offset, limit).

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,13 +2,18 @@ pub mod memory;
 mod table_codec;
 pub mod kip;
 
+use std::collections::VecDeque;
+use std::ops::SubAssign;
 use async_trait::async_trait;
 use kip_db::error::CacheError;
+use kip_db::kernel::lsm::mvcc;
 use kip_db::KernelError;
 use crate::catalog::{CatalogError, ColumnCatalog, TableCatalog, TableName};
 use crate::expression::ScalarExpression;
+use crate::expression::simplify::ConstantBinary;
+use crate::storage::table_codec::TableCodec;
 use crate::types::errors::TypeError;
-use crate::types::index::Index;
+use crate::types::index::{Index, IndexMetaRef};
 use crate::types::tuple::{Tuple, TupleId};
 
 #[async_trait]
@@ -47,6 +52,14 @@ pub trait Transaction: Sync + Send + 'static {
         projection: Projections,
     ) -> Result<Self::IterType<'_>, StorageError>;
 
+    fn read_by_index(
+        &self,
+        bounds: Bounds,
+        projection: Projections,
+        index_meta: IndexMetaRef,
+        binaries: Vec<ConstantBinary>
+    ) -> Result<IndexIter<'_>, StorageError>;
+
     fn add_index(&mut self, index: Index, tuple_ids: Vec<TupleId>, is_unique: bool) -> Result<(), StorageError>;
 
     fn del_index(&mut self, index: &Index) -> Result<(), StorageError>;
@@ -58,8 +71,59 @@ pub trait Transaction: Sync + Send + 'static {
     async fn commit(self) -> Result<(), StorageError>;
 }
 
+// TODO: Table return optimization
+pub struct IndexIter<'a> {
+    projections: Projections,
+    table_codec: &'a TableCodec,
+    tuple_ids: VecDeque<TupleId>,
+    tx: &'a mvcc::Transaction
+}
+
+impl Iter for IndexIter<'_> {
+    fn next_tuple(&mut self) -> Result<Option<Tuple>, StorageError> {
+        if let Some(tuple_id) = self.tuple_ids.pop_front() {
+            let key = self.table_codec.encode_tuple_key(&tuple_id)?;
+
+            Ok(self.tx.get(&key)?
+                .map(|bytes| tuple_projection(
+                    &mut None,
+                    &self.projections,
+                    self.table_codec.decode_tuple(&bytes)
+                ))
+                .transpose()?)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 pub trait Iter: Sync + Send {
     fn next_tuple(&mut self) -> Result<Option<Tuple>, StorageError>;
+}
+
+pub(crate) fn tuple_projection(
+    limit: &mut Option<usize>,
+    projections: &Projections,
+    tuple: Tuple
+) -> Result<Tuple, StorageError> {
+    let projection_len = projections.len();
+    let mut columns = Vec::with_capacity(projection_len);
+    let mut values = Vec::with_capacity(projection_len);
+
+    for expr in projections.iter() {
+        values.push(expr.eval_column(&tuple)?);
+        columns.push(expr.output_columns(&tuple));
+    }
+
+    if let Some(num) = limit {
+        num.sub_assign(1);
+    }
+
+    Ok(Tuple {
+        id: tuple.id,
+        columns,
+        values,
+    })
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -165,7 +165,7 @@ impl TableCodec {
                     table_name,
                     BOUND_MIN_TAG,
                     col.name,
-                    col.id,
+                    col.id.unwrap(),
                     width = COLUMNS_ID_LEN
                 );
 
@@ -360,7 +360,7 @@ mod tests {
                 "{}_Catalog_0_{}_{:0width$}",
                 table_catalog.name,
                 col.name,
-                col.id,
+                col.id.unwrap(),
                 width = COLUMNS_ID_LEN
             )
         );

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use bytes::Bytes;
+use lazy_static::lazy_static;
 use crate::catalog::{ColumnCatalog, TableCatalog, TableName};
 use crate::types::errors::TypeError;
 use crate::types::index::{Index, IndexId, IndexMeta};
@@ -7,74 +7,126 @@ use crate::types::tuple::{Tuple, TupleId};
 
 const BOUND_MIN_TAG: u8 = 0;
 const BOUND_MAX_TAG: u8 = 1;
-
-const COLUMNS_ID_LEN: usize = 10;
+lazy_static! {
+    static ref ROOT_BYTES: Vec<u8> = {
+        b"Root".to_vec()
+    };
+}
 
 #[derive(Clone)]
 pub struct TableCodec {
     pub table: TableCatalog
 }
 
+#[derive(Copy, Clone)]
+enum CodecType {
+    Column,
+    IndexMeta,
+    Index,
+    Tuple,
+    Root,
+}
+
 impl TableCodec {
+    /// TableName + Type
+    ///
+    /// Tips: Root full key = key_prefix
+    fn key_prefix(ty: CodecType, table_name: &String) -> Vec<u8> {
+        let mut table_bytes = table_name
+            .clone()
+            .into_bytes();
+
+        match ty {
+            CodecType::Column => {
+                table_bytes.push(b'0');
+            }
+            CodecType::IndexMeta => {
+                table_bytes.push(b'1');
+            }
+            CodecType::Index => {
+                table_bytes.push(b'2');
+            }
+            CodecType::Tuple => {
+                table_bytes.push(b'3');
+            }
+            CodecType::Root => {
+                let mut bytes = ROOT_BYTES.clone();
+                bytes.push(BOUND_MIN_TAG);
+                bytes.append(&mut table_bytes);
+
+                table_bytes = bytes
+            }
+        }
+
+        table_bytes
+    }
+
     pub fn tuple_bound(&self) -> (Vec<u8>, Vec<u8>) {
         let op = |bound_id| {
-            format!(
-                "{}_Tuple_{}",
-                self.table.name,
-                bound_id
-            )
+            let mut key_prefix = Self::key_prefix(CodecType::Tuple, &self.table.name);
+
+            key_prefix.push(bound_id);
+            key_prefix
         };
 
-        (op(BOUND_MIN_TAG).into_bytes(), op(BOUND_MAX_TAG).into_bytes())
+        (op(BOUND_MIN_TAG), op(BOUND_MAX_TAG))
     }
 
     pub fn index_meta_bound(name: &String) -> (Vec<u8>, Vec<u8>) {
         let op = |bound_id| {
-            format!(
-                "{}_IndexMeta_{}",
-                name,
-                bound_id
-            )
+            let mut key_prefix = Self::key_prefix(CodecType::IndexMeta, name);
+
+            key_prefix.push(bound_id);
+            key_prefix
         };
 
-        (op(BOUND_MIN_TAG).into_bytes(), op(BOUND_MAX_TAG).into_bytes())
+        (op(BOUND_MIN_TAG), op(BOUND_MAX_TAG))
     }
 
     pub fn index_bound(&self, index_id: &IndexId) -> (Vec<u8>, Vec<u8>) {
         let op = |bound_id| {
-            format!(
-                "{}_Index_0_{}_{}",
-                self.table.name,
-                index_id,
-                bound_id
-            )
+            let mut key_prefix = Self::key_prefix(CodecType::Index, &self.table.name);
+
+            key_prefix.push(BOUND_MIN_TAG);
+            key_prefix.append(&mut index_id.to_be_bytes().to_vec());
+            key_prefix.push(bound_id);
+            key_prefix
         };
 
-        (op(BOUND_MIN_TAG).into_bytes(), op(BOUND_MAX_TAG).into_bytes())
+        (op(BOUND_MIN_TAG), op(BOUND_MAX_TAG))
     }
 
     pub fn all_index_bound(&self) -> (Vec<u8>, Vec<u8>) {
         let op = |bound_id| {
-            format!(
-                "{}_Index_{}",
-                self.table.name,
-                bound_id
-            )
+            let mut key_prefix = Self::key_prefix(CodecType::Index, &self.table.name);
+
+            key_prefix.push(bound_id);
+            key_prefix
         };
 
-        (op(BOUND_MIN_TAG).into_bytes(), op(BOUND_MAX_TAG).into_bytes())
+        (op(BOUND_MIN_TAG), op(BOUND_MAX_TAG))
+    }
+
+    pub fn root_table_bound() -> (Vec<u8>, Vec<u8>) {
+        let op = |bound_id| {
+            let mut key_prefix = ROOT_BYTES.clone();
+
+            key_prefix.push(bound_id);
+            key_prefix
+        };
+
+        (op(BOUND_MIN_TAG), op(BOUND_MAX_TAG))
     }
 
     pub fn columns_bound(name: &String) -> (Vec<u8>, Vec<u8>) {
         let op = |bound_id| {
-            format!(
-                "{}_Catalog_{}",
-                name,
-                bound_id
-            )
+            let mut key_prefix = Self::key_prefix(CodecType::Column, &name);
+
+            key_prefix.push(bound_id);
+            key_prefix
         };
 
-        (op(BOUND_MIN_TAG).into_bytes(), op(BOUND_MAX_TAG).into_bytes())
+        (op(BOUND_MIN_TAG), op(BOUND_MAX_TAG))
     }
 
     /// Key: TableName_Tuple_0_RowID(Sorted)
@@ -90,14 +142,12 @@ impl TableCodec {
     }
 
     pub fn encode_tuple_key(&self, tuple_id: &TupleId) -> Result<Vec<u8>, TypeError> {
-        let mut string_key = format!(
-            "{}_Tuple_0_",
-            self.table.name,
-        ).into_bytes();
+        let mut key_prefix = Self::key_prefix(CodecType::Tuple, &self.table.name);
+        key_prefix.push(BOUND_MIN_TAG);
 
-        tuple_id.to_primary_key(&mut string_key)?;
+        tuple_id.to_primary_key(&mut key_prefix)?;
 
-        Ok(string_key)
+        Ok(key_prefix)
     }
 
     pub fn decode_tuple(&self, bytes: &[u8]) -> Tuple {
@@ -107,13 +157,11 @@ impl TableCodec {
     /// Key: TableName_IndexMeta_0_IndexID
     /// Value: IndexMeta
     pub fn encode_index_meta(name: &String, index_meta: &IndexMeta) -> Result<(Bytes, Bytes), TypeError> {
-        let key = format!(
-            "{}_IndexMeta_0_{}",
-            name,
-            index_meta.id
-        );
+        let mut key_prefix = Self::key_prefix(CodecType::IndexMeta, &name);
+        key_prefix.push(BOUND_MIN_TAG);
+        key_prefix.append(&mut index_meta.id.to_be_bytes().to_vec());
 
-        Ok((Bytes::from(key), Bytes::from(bincode::serialize(&index_meta)?)))
+        Ok((Bytes::from(key_prefix), Bytes::from(bincode::serialize(&index_meta)?)))
     }
 
     pub fn decode_index_meta(bytes: &[u8]) -> Result<IndexMeta, TypeError> {
@@ -137,17 +185,16 @@ impl TableCodec {
     }
 
     pub fn encode_index_key(&self, index: &Index) -> Result<Vec<u8>, TypeError> {
-        let mut string_key = format!(
-            "{}_Index_0_{}_0",
-            self.table.name,
-            index.id
-        ).into_bytes();
+        let mut key_prefix = Self::key_prefix(CodecType::Index, &self.table.name);
+        key_prefix.push(BOUND_MIN_TAG);
+        key_prefix.append(&mut index.id.to_be_bytes().to_vec());
+        key_prefix.push(BOUND_MIN_TAG);
 
         for col_v in &index.column_values {
-            col_v.to_index_key(&mut string_key)?;
+            col_v.to_index_key(&mut key_prefix)?;
         }
 
-        Ok(string_key)
+        Ok(key_prefix)
     }
 
     pub fn decode_index(bytes: &[u8]) -> Result<Vec<TupleId>, TypeError> {
@@ -158,74 +205,37 @@ impl TableCodec {
     /// Value: ColumnCatalog
     ///
     /// Tips: the `0` for bound range
-    pub fn encode_column(table_name: &String, col: &ColumnCatalog) -> Option<(Bytes, Bytes)> {
-        bincode::serialize(col).ok()
-            .map(|bytes| {
-                let key = format!(
-                    "{}_Catalog_{}_{}_{:0width$}",
-                    table_name,
-                    BOUND_MIN_TAG,
-                    col.name,
-                    col.id.unwrap(),
-                    width = COLUMNS_ID_LEN
-                );
+    pub fn encode_column(col: &ColumnCatalog) -> Result<(Bytes, Bytes), TypeError> {
+        let bytes = bincode::serialize(col)?;
+        let mut key_prefix = Self::key_prefix(CodecType::Column, col.table_name.as_ref().unwrap());
 
-                (Bytes::from(key.into_bytes()), Bytes::from(bytes))
-            })
+        key_prefix.push(BOUND_MIN_TAG);
+        key_prefix.append(&mut col.id.unwrap().to_be_bytes().to_vec());
+
+        Ok((Bytes::from(key_prefix), Bytes::from(bytes)))
     }
 
-    pub fn decode_column(key: &[u8], bytes: &[u8]) -> Option<(TableName, ColumnCatalog)> {
-        String::from_utf8(key.to_owned()).ok()?
-            .split("_")
-            .nth(0)
-            .and_then(|table_name| {
-                bincode::deserialize::<ColumnCatalog>(bytes).ok()
-                    .and_then(|col| {
-                        Some((Arc::new(table_name.to_string()), col))
-                    })
-            })
+    pub fn decode_column(bytes: &[u8]) -> Result<(TableName, ColumnCatalog), TypeError> {
+        let column = bincode::deserialize::<ColumnCatalog>(bytes)?;
+
+        Ok((column.table_name.clone().unwrap(), column))
     }
 
 
     /// Key: RootCatalog_0_TableName
-    /// Value: ColumnCount
-    pub fn encode_root_table(table_name: &str,column_count:usize) -> Result<(Bytes, Bytes), TypeError> {
+    /// Value: TableName
+    pub fn encode_root_table(table_name: &String) -> Result<(Bytes, Bytes), TypeError> {
         let key = Self::encode_root_table_key(table_name);
-        let bytes = bincode::serialize(&column_count)?;
 
-        Ok((Bytes::from(key), Bytes::from(bytes)))
+        Ok((Bytes::from(key), Bytes::from(table_name.clone().into_bytes())))
     }
 
-    pub fn encode_root_table_key(table_name: &str) -> Vec<u8> {
-        format!(
-            "RootCatalog_{}_{}",
-            BOUND_MIN_TAG,
-            table_name,
-        ).into_bytes()
+    pub fn encode_root_table_key(table_name: &String) -> Vec<u8> {
+        Self::key_prefix(CodecType::Root, &table_name)
     }
 
-    // TODO: value is reserved for saving meta-information
-    pub fn decode_root_table(key: &[u8], bytes: &[u8]) -> Option<(String,usize)> {
-        String::from_utf8(key.to_owned()).ok()?
-            .split("_")
-            .nth(2)
-            .and_then(|table_name| {
-                bincode::deserialize::<usize>(bytes).ok()
-                    .and_then(|name| {
-                        Some((table_name.to_string(), name))
-                    })
-            })
-    }
-
-    pub fn root_table_bound() -> (Vec<u8>, Vec<u8>) {
-        let op = |bound_id| {
-            format!(
-                "RootCatalog_{}",
-                bound_id,
-            )
-        };
-
-        (op(BOUND_MIN_TAG).into_bytes(), op(BOUND_MAX_TAG).into_bytes())
+    pub fn decode_root_table(bytes: &[u8]) -> Result<String, TypeError> {
+        Ok(String::from_utf8(bytes.to_vec())?)
     }
 }
 
@@ -234,10 +244,11 @@ mod tests {
     use std::collections::BTreeSet;
     use std::ops::Bound;
     use std::sync::Arc;
+    use bytes::Bytes;
     use itertools::Itertools;
     use rust_decimal::Decimal;
     use crate::catalog::{ColumnCatalog, ColumnDesc, TableCatalog};
-    use crate::storage::table_codec::{COLUMNS_ID_LEN, TableCodec};
+    use crate::storage::table_codec::TableCodec;
     use crate::types::errors::TypeError;
     use crate::types::index::{Index, IndexMeta};
     use crate::types::LogicalType;
@@ -257,7 +268,7 @@ mod tests {
                 ColumnDesc::new(LogicalType::Decimal(None,None), false, false)
             ),
         ];
-        let table_catalog = TableCatalog::new(Arc::new("t1".to_string()), columns, vec![]).unwrap();
+        let table_catalog = TableCatalog::new(Arc::new("t1".to_string()), columns).unwrap();
         let codec = TableCodec { table: table_catalog.clone() };
         (table_catalog, codec)
     }
@@ -274,13 +285,8 @@ mod tests {
                 Arc::new(DataValue::Decimal(Some(Decimal::new(1, 0)))),
             ]
         };
+        let (_, bytes) = codec.encode_tuple(&tuple)?;
 
-        let (key, bytes) = codec.encode_tuple(&tuple)?;
-
-        let mut test_key = format!("{}_Tuple_0_", table_catalog.name).into_bytes();
-        tuple.id.clone().unwrap().to_primary_key(&mut test_key)?;
-
-        assert_eq!(key.to_vec(), test_key);
         assert_eq!(codec.decode_tuple(&bytes), tuple);
 
         Ok(())
@@ -289,20 +295,11 @@ mod tests {
     #[test]
     fn test_root_catalog() {
         let (table_catalog, _) = build_table_codec();
-        let (key, bytes) = TableCodec::encode_root_table(&table_catalog.name,2).unwrap();
+        let (_, bytes) = TableCodec::encode_root_table(&table_catalog.name).unwrap();
 
-        assert_eq!(
-            String::from_utf8(key.to_vec()).ok().unwrap(),
-            format!(
-                "RootCatalog_0_{}",
-                table_catalog.name,
-            )
-        );
-
-        let (table_name, column_count) = TableCodec::decode_root_table(&key, &bytes).unwrap();
+        let table_name = TableCodec::decode_root_table(&bytes).unwrap();
 
         assert_eq!(table_name, table_catalog.name.as_str());
-        assert_eq!(column_count, 2);
     }
 
     #[test]
@@ -313,16 +310,8 @@ mod tests {
             name: "index_1".to_string(),
             is_unique: false,
         };
+        let (_, bytes) = TableCodec::encode_index_meta(&"T1".to_string(), &index_meta)?;
 
-        let (key, bytes) = TableCodec::encode_index_meta(&"T1".to_string(), &index_meta)?;
-
-        assert_eq!(
-            String::from_utf8(key.to_vec()).ok().unwrap(),
-            format!(
-                "T1_IndexMeta_0_{}",
-                index_meta.id
-            )
-        );
         assert_eq!(TableCodec::decode_index_meta(&bytes)?, index_meta);
 
         Ok(())
@@ -330,24 +319,15 @@ mod tests {
 
     #[test]
     fn test_table_codec_index() -> Result<(), TypeError> {
-        let (table_catalog, codec) = build_table_codec();
+        let (_, codec) = build_table_codec();
 
         let index = Index {
             id: 0,
             column_values: vec![Arc::new(DataValue::Int32(Some(0)))],
         };
         let tuple_ids = vec![Arc::new(DataValue::Int32(Some(0)))];
+        let (_, bytes) = codec.encode_index(&index, &tuple_ids)?;
 
-        let (key, bytes) = codec.encode_index(&index, &tuple_ids)?;
-
-        let mut test_key = format!(
-            "{}_Index_0_{}_0",
-            table_catalog.name,
-            index.id,
-        ).into_bytes();
-        index.column_values[0].to_index_key(&mut test_key)?;
-
-        assert_eq!(key.to_vec(), test_key);
         assert_eq!(TableCodec::decode_index(&bytes)?, tuple_ids);
 
         Ok(())
@@ -357,20 +337,9 @@ mod tests {
     fn test_table_codec_column() {
         let (table_catalog, _) = build_table_codec();
         let col = table_catalog.all_columns()[0].clone();
-        let (key, bytes) = TableCodec::encode_column(&table_catalog.name, &col).unwrap();
+        let (_, bytes) = TableCodec::encode_column(&col).unwrap();
 
-        assert_eq!(
-            String::from_utf8(key.to_vec()).ok().unwrap(),
-            format!(
-                "{}_Catalog_0_{}_{:0width$}",
-                table_catalog.name,
-                col.name,
-                col.id.unwrap(),
-                width = COLUMNS_ID_LEN
-            )
-        );
-
-        let (table_name, decode_col) = TableCodec::decode_column(&key, &bytes).unwrap();
+        let (table_name, decode_col) = TableCodec::decode_column(&bytes).unwrap();
 
         assert_eq!(&decode_col, col.as_ref());
         assert_eq!(table_name, table_catalog.name);
@@ -379,92 +348,131 @@ mod tests {
     #[test]
     fn test_table_codec_column_bound() {
         let mut set = BTreeSet::new();
-        let op = |str: &str| {
-            str.to_string().into_bytes()
+        let op = |col_id: usize, table_name: &str| {
+            let mut col = ColumnCatalog::new(
+                "".to_string(),
+                false,
+                ColumnDesc {
+                    column_datatype: LogicalType::Invalid,
+                    is_primary: false,
+                    is_unique: false,
+                }
+            );
+
+            col.table_name = Some(Arc::new(table_name.to_string()));
+            col.id = Some(col_id as u32);
+
+            let (key, _) = TableCodec::encode_column(&col).unwrap();
+            key
         };
 
-        set.insert(op("T0_Catalog_0_C0_0"));
-        set.insert(op("T0_Catalog_0_C1_1"));
-        set.insert(op("T0_Catalog_0_C2_2"));
+        set.insert(op(0, "T0"));
+        set.insert(op(1, "T0"));
+        set.insert(op(2, "T0"));
 
-        set.insert(op("T1_Catalog_0_C0_0"));
-        set.insert(op("T1_Catalog_0_C1_1"));
-        set.insert(op("T1_Catalog_0_C2_2"));
+        set.insert(op(0, "T1"));
+        set.insert(op(1, "T1"));
+        set.insert(op(2, "T1"));
 
-        set.insert(op("T2_Catalog_0_C0_0"));
-        set.insert(op("T2_Catalog_0_C1_1"));
-        set.insert(op("T2_Catalog_0_C2_2"));
+        set.insert(op(0, "T2"));
+        set.insert(op(0, "T2"));
+        set.insert(op(0, "T2"));
 
         let (min, max) = TableCodec::columns_bound(
             &Arc::new("T1".to_string())
         );
 
         let vec = set
-            .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((Bound::Included(&min), Bound::Included(&max)))
+            .range::<Bytes, (Bound<&Bytes>, Bound<&Bytes>)>((
+                Bound::Included(&Bytes::from(min)),
+                Bound::Included(&Bytes::from(max))
+            ))
             .collect_vec();
 
         assert_eq!(vec.len(), 3);
 
-        assert_eq!(String::from_utf8(vec[0].clone()).unwrap(), "T1_Catalog_0_C0_0");
-        assert_eq!(String::from_utf8(vec[1].clone()).unwrap(), "T1_Catalog_0_C1_1");
-        assert_eq!(String::from_utf8(vec[2].clone()).unwrap(), "T1_Catalog_0_C2_2");
+        assert_eq!(vec[0], &op(0, "T1"));
+        assert_eq!(vec[1], &op(1, "T1"));
+        assert_eq!(vec[2], &op(2, "T1"));
     }
 
     #[test]
     fn test_table_codec_index_meta_bound() {
         let mut set = BTreeSet::new();
-        let op = |str: &str| {
-            str.to_string().into_bytes()
+        let op = |index_id: usize, table_name: &str| {
+            let index_meta = IndexMeta {
+                id: index_id as u32,
+                column_ids: vec![],
+                name: "".to_string(),
+                is_unique: false,
+            };
+
+            let (key, _) = TableCodec::encode_index_meta(&table_name.to_string(), &index_meta).unwrap();
+            key
         };
 
-        set.insert(op("T0_IndexMeta_0_0"));
-        set.insert(op("T0_IndexMeta_0_1"));
-        set.insert(op("T0_IndexMeta_0_2"));
+        set.insert(op(0, "T0"));
+        set.insert(op(1, "T0"));
+        set.insert(op(2, "T0"));
 
-        set.insert(op("T1_IndexMeta_0_0"));
-        set.insert(op("T1_IndexMeta_0_1"));
-        set.insert(op("T1_IndexMeta_0_2"));
+        set.insert(op(0, "T1"));
+        set.insert(op(1, "T1"));
+        set.insert(op(2, "T1"));
 
-        set.insert(op("T2_IndexMeta_0_0"));
-        set.insert(op("T2_IndexMeta_0_1"));
-        set.insert(op("T2_IndexMeta_0_2"));
+        set.insert(op(0, "T2"));
+        set.insert(op(1, "T2"));
+        set.insert(op(2, "T2"));
 
         let (min, max) = TableCodec::index_meta_bound(&"T1".to_string());
 
         let vec = set
-            .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((Bound::Included(&min), Bound::Included(&max)))
+            .range::<Bytes, (Bound<&Bytes>, Bound<&Bytes>)>((
+                Bound::Included(&Bytes::from(min)),
+                Bound::Included(&Bytes::from(max))
+            ))
             .collect_vec();
 
         assert_eq!(vec.len(), 3);
 
-        assert_eq!(String::from_utf8(vec[0].clone()).unwrap(), "T1_IndexMeta_0_0");
-        assert_eq!(String::from_utf8(vec[1].clone()).unwrap(), "T1_IndexMeta_0_1");
-        assert_eq!(String::from_utf8(vec[2].clone()).unwrap(), "T1_IndexMeta_0_2");
+        assert_eq!(vec[0], &op(0, "T1"));
+        assert_eq!(vec[1], &op(1, "T1"));
+        assert_eq!(vec[2], &op(2, "T1"));
     }
 
     #[test]
     fn test_table_codec_index_bound() {
         let mut set = BTreeSet::new();
-        let op = |str: &str| {
-            str.to_string().into_bytes()
-        };
-
-        set.insert(op("T0_Index_0_0_0_0000000000000000000"));
-        set.insert(op("T0_Index_0_0_0_0000000000000000001"));
-        set.insert(op("T0_Index_0_0_0_0000000000000000002"));
-
-        set.insert(op("T0_Index_0_1_0_0000000000000000000"));
-        set.insert(op("T0_Index_0_1_0_0000000000000000001"));
-        set.insert(op("T0_Index_0_1_0_0000000000000000002"));
-
-        set.insert(op("T0_Index_0_2_0_0000000000000000000"));
-        set.insert(op("T0_Index_0_2_0_0000000000000000001"));
-        set.insert(op("T0_Index_0_2_0_0000000000000000002"));
-
         let table_codec = TableCodec {
-            table: TableCatalog::new(Arc::new("T0".to_string()), vec![], vec![]).unwrap(),
+            table: TableCatalog::new(Arc::new("T0".to_string()), vec![]).unwrap(),
         };
+
+        let op = |value: DataValue, index_id: usize, table_codec: &TableCodec| {
+            let index = Index {
+                id: index_id as u32,
+                column_values: vec![Arc::new(value)],
+            };
+
+            table_codec.encode_index_key(&index).unwrap()
+        };
+
+        set.insert(op(DataValue::Int32(Some(0)), 0, &table_codec));
+        set.insert(op(DataValue::Int32(Some(1)), 0, &table_codec));
+        set.insert(op(DataValue::Int32(Some(2)), 0, &table_codec));
+
+        set.insert(op(DataValue::Int32(Some(0)), 1, &table_codec));
+        set.insert(op(DataValue::Int32(Some(1)), 1, &table_codec));
+        set.insert(op(DataValue::Int32(Some(2)), 1, &table_codec));
+
+        set.insert(op(DataValue::Int32(Some(0)), 2, &table_codec));
+        set.insert(op(DataValue::Int32(Some(1)), 2, &table_codec));
+        set.insert(op(DataValue::Int32(Some(2)), 2, &table_codec));
+
+        println!("{:#?}", set);
+
         let (min, max) = table_codec.index_bound(&1);
+
+        println!("{:?}", min);
+        println!("{:?}", max);
 
         let vec = set
             .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((Bound::Included(&min), Bound::Included(&max)))
@@ -472,32 +480,39 @@ mod tests {
 
         assert_eq!(vec.len(), 3);
 
-        assert_eq!(String::from_utf8(vec[0].clone()).unwrap(), "T0_Index_0_1_0_0000000000000000000");
-        assert_eq!(String::from_utf8(vec[1].clone()).unwrap(), "T0_Index_0_1_0_0000000000000000001");
-        assert_eq!(String::from_utf8(vec[2].clone()).unwrap(), "T0_Index_0_1_0_0000000000000000002");
+        assert_eq!(vec[0], &op(DataValue::Int32(Some(0)), 1, &table_codec));
+        assert_eq!(vec[1], &op(DataValue::Int32(Some(1)), 1, &table_codec));
+        assert_eq!(vec[2], &op(DataValue::Int32(Some(2)), 1, &table_codec));
     }
 
     #[test]
     fn test_table_codec_index_all_bound() {
         let mut set = BTreeSet::new();
-        let op = |str: &str| {
-            str.to_string().into_bytes()
+        let op = |value: DataValue, index_id: usize, table_name: &str| {
+            let index = Index {
+                id: index_id as u32,
+                column_values: vec![Arc::new(value)],
+            };
+
+            TableCodec {
+                table: TableCatalog::new(Arc::new(table_name.to_string()), vec![]).unwrap()
+            }.encode_index_key(&index).unwrap()
         };
 
-        set.insert(op("T0_Index_0_0_0_0000000000000000000"));
-        set.insert(op("T0_Index_0_0_0_0000000000000000001"));
-        set.insert(op("T0_Index_0_0_0_0000000000000000002"));
+        set.insert(op(DataValue::Int32(Some(0)), 0, "T0"));
+        set.insert(op(DataValue::Int32(Some(1)), 0, "T0"));
+        set.insert(op(DataValue::Int32(Some(2)), 0, "T0"));
 
-        set.insert(op("T1_Index_0_1_0_0000000000000000000"));
-        set.insert(op("T1_Index_0_1_0_0000000000000000001"));
-        set.insert(op("T1_Index_0_1_0_0000000000000000002"));
+        set.insert(op(DataValue::Int32(Some(0)), 0, "T1"));
+        set.insert(op(DataValue::Int32(Some(1)), 0, "T1"));
+        set.insert(op(DataValue::Int32(Some(2)), 0, "T1"));
 
-        set.insert(op("T2_Index_0_2_0_0000000000000000000"));
-        set.insert(op("T2_Index_0_2_0_0000000000000000001"));
-        set.insert(op("T2_Index_0_2_0_0000000000000000002"));
+        set.insert(op(DataValue::Int32(Some(0)), 0, "T2"));
+        set.insert(op(DataValue::Int32(Some(1)), 0, "T2"));
+        set.insert(op(DataValue::Int32(Some(2)), 0, "T2"));
 
         let table_codec = TableCodec {
-            table: TableCatalog::new(Arc::new("T1".to_string()), vec![], vec![]).unwrap(),
+            table: TableCatalog::new(Arc::new("T1".to_string()), vec![]).unwrap(),
         };
         let (min, max) = table_codec.all_index_bound();
 
@@ -507,32 +522,34 @@ mod tests {
 
         assert_eq!(vec.len(), 3);
 
-        assert_eq!(String::from_utf8(vec[0].clone()).unwrap(), "T1_Index_0_1_0_0000000000000000000");
-        assert_eq!(String::from_utf8(vec[1].clone()).unwrap(), "T1_Index_0_1_0_0000000000000000001");
-        assert_eq!(String::from_utf8(vec[2].clone()).unwrap(), "T1_Index_0_1_0_0000000000000000002");
+        assert_eq!(vec[0], &op(DataValue::Int32(Some(0)), 0, "T1"));
+        assert_eq!(vec[1], &op(DataValue::Int32(Some(1)), 0, "T1"));
+        assert_eq!(vec[2], &op(DataValue::Int32(Some(2)), 0, "T1"));
     }
 
     #[test]
     fn test_table_codec_tuple_bound() {
         let mut set = BTreeSet::new();
-        let op = |str: &str| {
-            str.to_string().into_bytes()
+        let op = |tuple_id: DataValue, table_name: &str| {
+            TableCodec {
+                table: TableCatalog::new(Arc::new(table_name.to_string()), vec![]).unwrap()
+            }.encode_tuple_key(&Arc::new(tuple_id)).unwrap()
         };
 
-        set.insert(op("T0_Tuple_0_0000000000000000000"));
-        set.insert(op("T0_Tuple_0_0000000000000000001"));
-        set.insert(op("T0_Tuple_0_0000000000000000002"));
+        set.insert(op(DataValue::Int32(Some(0)), "T0"));
+        set.insert(op(DataValue::Int32(Some(1)), "T0"));
+        set.insert(op(DataValue::Int32(Some(2)), "T0"));
 
-        set.insert(op("T1_Tuple_0_0000000000000000000"));
-        set.insert(op("T1_Tuple_0_0000000000000000001"));
-        set.insert(op("T1_Tuple_0_0000000000000000002"));
+        set.insert(op(DataValue::Int32(Some(0)), "T1"));
+        set.insert(op(DataValue::Int32(Some(1)), "T1"));
+        set.insert(op(DataValue::Int32(Some(2)), "T1"));
 
-        set.insert(op("T2_Tuple_0_0000000000000000000"));
-        set.insert(op("T2_Tuple_0_0000000000000000001"));
-        set.insert(op("T2_Tuple_0_0000000000000000002"));
+        set.insert(op(DataValue::Int32(Some(0)), "T2"));
+        set.insert(op(DataValue::Int32(Some(1)), "T2"));
+        set.insert(op(DataValue::Int32(Some(2)), "T2"));
 
         let table_codec = TableCodec {
-            table: TableCatalog::new(Arc::new("T1".to_string()), vec![], vec![]).unwrap(),
+            table: TableCatalog::new(Arc::new("T1".to_string()), vec![]).unwrap(),
         };
         let (min, max) = table_codec.tuple_bound();
 
@@ -542,21 +559,25 @@ mod tests {
 
         assert_eq!(vec.len(), 3);
 
-        assert_eq!(String::from_utf8(vec[0].clone()).unwrap(), "T1_Tuple_0_0000000000000000000");
-        assert_eq!(String::from_utf8(vec[1].clone()).unwrap(), "T1_Tuple_0_0000000000000000001");
-        assert_eq!(String::from_utf8(vec[2].clone()).unwrap(), "T1_Tuple_0_0000000000000000002");
+        assert_eq!(vec[0], &op(DataValue::Int32(Some(0)), "T1"));
+        assert_eq!(vec[1], &op(DataValue::Int32(Some(1)), "T1"));
+        assert_eq!(vec[2], &op(DataValue::Int32(Some(2)), "T1"));
     }
 
     #[test]
     fn test_root_codec_name_bound(){
         let mut set = BTreeSet::new();
-        let op = |str: &str| {
-            str.to_string().into_bytes()
+        let op = |table_name: &str| {
+            TableCodec::encode_root_table_key(&table_name.to_string())
         };
 
-        set.insert(op("RootCatalog_0_T0"));
-        set.insert(op("RootCatalog_0_T1"));
-        set.insert(op("RootCatalog_0_T2"));
+        set.insert(b"A".to_vec());
+
+        set.insert(op("T0"));
+        set.insert(op("T1"));
+        set.insert(op("T2"));
+
+        set.insert(b"Z".to_vec());
 
         let (min, max) = TableCodec::root_table_bound();
 
@@ -564,9 +585,9 @@ mod tests {
             .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((Bound::Included(&min), Bound::Included(&max)))
             .collect_vec();
 
-        assert_eq!(String::from_utf8(vec[0].clone()).unwrap(), "RootCatalog_0_T0");
-        assert_eq!(String::from_utf8(vec[1].clone()).unwrap(), "RootCatalog_0_T1");
-        assert_eq!(String::from_utf8(vec[2].clone()).unwrap(), "RootCatalog_0_T2");
+        assert_eq!(vec[0], &op("T0"));
+        assert_eq!(vec[1], &op("T1"));
+        assert_eq!(vec[2], &op("T2"));
 
     }
 }

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -121,11 +121,11 @@ impl TableCodec {
 
     /// NonUnique Index:
     /// Key: TableName_Index_0_IndexID_0_DataValue1_DataValue2 ..
-    /// Value: IndexValue
+    /// Value: TupleIDs
     ///
     /// Unique Index:
     /// Key: TableName_Index_0_IndexID_0_DataValue
-    /// Value: IndexValue
+    /// Value: TupleIDs
     ///
     /// Tips: The unique index has only one ColumnID and one corresponding DataValue,
     /// so it can be positioned directly.

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -249,13 +249,11 @@ mod tests {
                 "c1".into(),
                 false,
                 ColumnDesc::new(LogicalType::Integer, true, false)
-            )
-                ColumnDesc::new(LogicalType::Integer, true, false)
             ),
             ColumnCatalog::new(
                 "c2".into(),
                 false,
-                ColumnDesc::new(LogicalType::Decimal(None,None), false)
+                ColumnDesc::new(LogicalType::Decimal(None,None), false, false)
             ),
         ];
         let table_catalog = TableCatalog::new(Arc::new("t1".to_string()), columns, vec![]).unwrap();

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use bytes::Bytes;
-use crate::catalog::{ColumnCatalog, ColumnRef, TableCatalog, TableName};
+use crate::catalog::{ColumnCatalog, TableCatalog, TableName};
 use crate::types::errors::TypeError;
 use crate::types::index::{Index, IndexId, IndexMeta, IndexValue};
 use crate::types::tuple::{Tuple, TupleId};
@@ -289,8 +289,6 @@ mod tests {
 
     #[test]
     fn test_table_codec_index_meta() -> Result<(), TypeError> {
-        let (_, codec) = build_table_codec();
-
         let index_meta = IndexMeta {
             id: 0,
             column_ids: vec![0],

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -188,17 +188,19 @@ impl TableCodec {
 
     /// Key: RootCatalog_0_TableName
     /// Value: ColumnCount
-    pub fn encode_root_table(table_name: &str,column_count:usize) -> Option<(Bytes, Bytes)> {
-        let key = format!(
+    pub fn encode_root_table(table_name: &str,column_count:usize) -> Result<(Bytes, Bytes), TypeError> {
+        let key = Self::encode_root_table_key(table_name);
+        let bytes = bincode::serialize(&column_count)?;
+
+        Ok((Bytes::from(key), Bytes::from(bytes)))
+    }
+
+    pub fn encode_root_table_key(table_name: &str) -> Vec<u8> {
+        format!(
             "RootCatalog_{}_{}",
             BOUND_MIN_TAG,
             table_name,
-        );
-
-        bincode::serialize(&column_count).ok()
-            .map(|bytes| {
-                (Bytes::from(key.into_bytes()), Bytes::from(bytes))
-            })
+        ).into_bytes()
     }
 
     // TODO: value is reserved for saving meta-information

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -51,7 +51,7 @@ pub enum TypeError {
         #[source]
         #[from]
         Box<bincode::ErrorKind>
-    )
+    ),
     #[error("try from decimal")]
     TryFromDecimal(
         #[source]

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -46,4 +46,10 @@ pub enum TypeError {
         #[from]
         ParseError,
     ),
+    #[error("bindcode")]
+    Bincode(
+        #[source]
+        #[from]
+        Box<bincode::ErrorKind>
+    )
 }

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -1,5 +1,6 @@
 use std::num::{ParseFloatError, ParseIntError, TryFromIntError};
 use std::str::ParseBoolError;
+use std::string::FromUtf8Error;
 use chrono::ParseError;
 
 #[derive(thiserror::Error, Debug)]
@@ -58,4 +59,10 @@ pub enum TypeError {
         #[from]
         rust_decimal::Error,
     ),
+    #[error("from utf8")]
+    FromUtf8Error(
+        #[source]
+        #[from]
+        FromUtf8Error,
+    )
 }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use crate::types::ColumnId;
-use crate::types::tuple::TupleId;
 use crate::types::value::ValueRef;
 
 pub type IndexId = u32;
@@ -16,10 +15,4 @@ pub struct IndexMeta {
 pub struct Index {
     pub id: IndexId,
     pub column_values: Vec<ValueRef>,
-    pub value: IndexValue
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct IndexValue {
-    pub tuple_ids: Vec<TupleId>,
 }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use crate::types::ColumnId;
+use crate::types::tuple::TupleId;
+use crate::types::value::ValueRef;
+
+pub type IndexId = u32;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct IndexMeta {
+    pub id: IndexId,
+    pub column_ids: Vec<ColumnId>,
+    pub name: String,
+}
+
+pub struct Index {
+    pub id: IndexId,
+    pub column_values: Vec<ValueRef>,
+    pub value: IndexValue
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct IndexValue {
+    pub tuple_ids: Vec<TupleId>,
+    pub is_unique:bool
+}

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -10,6 +10,7 @@ pub struct IndexMeta {
     pub id: IndexId,
     pub column_ids: Vec<ColumnId>,
     pub name: String,
+    pub is_unique:bool
 }
 
 pub struct Index {
@@ -21,5 +22,4 @@ pub struct Index {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct IndexValue {
     pub tuple_ids: Vec<TupleId>,
-    pub is_unique:bool
 }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -4,7 +4,7 @@ use crate::types::ColumnId;
 use crate::types::value::ValueRef;
 
 pub type IndexId = u32;
-pub type IndexRef = Arc<IndexMeta>;
+pub type IndexMetaRef = Arc<IndexMeta>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct IndexMeta {
@@ -17,4 +17,13 @@ pub struct IndexMeta {
 pub struct Index {
     pub id: IndexId,
     pub column_values: Vec<ValueRef>,
+}
+
+impl Index {
+    pub fn new(id: IndexId, column_values: Vec<ValueRef>) -> Self {
+        Index {
+            id,
+            column_values,
+        }
+    }
 }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use crate::types::ColumnId;
 use crate::types::value::ValueRef;
 
 pub type IndexId = u32;
+pub type IndexRef = Arc<IndexMeta>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct IndexMeta {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,7 +5,6 @@ pub mod index;
 
 use serde::{Deserialize, Serialize};
 
-use integer_encoding::FixedInt;
 use sqlparser::ast::ExactNumberInfo;
 use strum_macros::AsRefStr;
 
@@ -53,7 +52,7 @@ impl LogicalType {
             LogicalType::UBigint => Some(8),
             LogicalType::Float => Some(4),
             LogicalType::Double => Some(8),
-            /// Note: The non-fixed length type's raw_len is None e.g. Varchar and Decimal
+            /// Note: The non-fixed length type's raw_len is None e.g. Varchar
             LogicalType::Varchar(_) => None,
             LogicalType::Decimal(_, _) => Some(16),
             LogicalType::Date => Some(4),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,38 +3,10 @@ pub mod value;
 pub mod tuple;
 pub mod index;
 
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering::{Acquire, Release};
 use serde::{Deserialize, Serialize};
-
-use integer_encoding::FixedInt;
 use strum_macros::AsRefStr;
 
 use crate::types::errors::TypeError;
-
-static ID_BUF: AtomicU32 = AtomicU32::new(0);
-
-pub(crate) struct IdGenerator { }
-
-impl IdGenerator {
-    pub(crate) fn encode_to_raw() -> Vec<u8> {
-        ID_BUF
-            .load(Acquire)
-            .encode_fixed_vec()
-    }
-
-    pub(crate) fn from_raw(buf: &[u8]) {
-        Self::init(u32::decode_fixed(buf))
-    }
-
-    pub(crate) fn init(init_value: u32) {
-        ID_BUF.store(init_value, Release)
-    }
-
-    pub(crate) fn build() -> u32 {
-        ID_BUF.fetch_add(1, Release)
-    }
-}
 
 pub type ColumnId = u32;
 
@@ -307,34 +279,5 @@ impl TryFrom<sqlparser::ast::DataType> for LogicalType {
 impl std::fmt::Display for LogicalType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_ref())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::sync::atomic::Ordering::Release;
-
-    use crate::types::{IdGenerator, ID_BUF};
-
-    /// Tips: 由于IdGenerator为static全局性质生成的id，因此需要单独测试避免其他测试方法干扰
-    #[test]
-    #[ignore]
-    fn test_id_generator() {
-        assert_eq!(IdGenerator::build(), 0);
-        assert_eq!(IdGenerator::build(), 1);
-
-        let buf = IdGenerator::encode_to_raw();
-        test_id_generator_reset();
-
-        assert_eq!(IdGenerator::build(), 0);
-
-        IdGenerator::from_raw(&buf);
-
-        assert_eq!(IdGenerator::build(), 2);
-        assert_eq!(IdGenerator::build(), 3);
-    }
-
-    fn test_id_generator_reset() {
-        ID_BUF.store(0, Release)
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod errors;
 pub mod value;
 pub mod tuple;
+pub mod index;
 
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -313,7 +314,7 @@ impl std::fmt::Display for LogicalType {
 mod test {
     use std::sync::atomic::Ordering::Release;
 
-    use crate::types::{IdGenerator, ID_BUF, LogicalType};
+    use crate::types::{IdGenerator, ID_BUF};
 
     /// Tips: 由于IdGenerator为static全局性质生成的id，因此需要单独测试避免其他测试方法干扰
     #[test]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -125,12 +125,12 @@ mod tests {
             Arc::new(ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true)
+                ColumnDesc::new(LogicalType::Integer, true, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c2".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::UInteger, false)
+                ColumnDesc::new(LogicalType::UInteger, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c3".to_string(),
@@ -140,47 +140,47 @@ mod tests {
             Arc::new(ColumnCatalog::new(
                 "c4".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Smallint, false)
+                ColumnDesc::new(LogicalType::Smallint, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c5".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::USmallint, false)
+                ColumnDesc::new(LogicalType::USmallint, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c6".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Float, false)
+                ColumnDesc::new(LogicalType::Float, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c7".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Double, false)
+                ColumnDesc::new(LogicalType::Double, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c8".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Tinyint, false)
+                ColumnDesc::new(LogicalType::Tinyint, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c9".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::UTinyint, false)
+                ColumnDesc::new(LogicalType::UTinyint, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c10".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Boolean, false)
+                ColumnDesc::new(LogicalType::Boolean, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c11".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::DateTime, false)
+                ColumnDesc::new(LogicalType::DateTime, false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c12".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Date, false)
+                ColumnDesc::new(LogicalType::Date, false, false)
             )),
         ];
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -18,7 +18,7 @@ pub struct Tuple {
 
 impl Tuple {
     pub fn deserialize_from(columns: Vec<ColumnRef>, bytes: &[u8]) -> Self {
-        fn bit_index(bits: u8, i: usize) -> bool {
+        fn is_none(bits: u8, i: usize) -> bool {
             bits & (1 << (7 - i)) > 0
         }
 
@@ -32,7 +32,7 @@ impl Tuple {
         for (i, col) in columns.iter().enumerate() {
             let logic_type = col.datatype();
 
-            if bit_index(bytes[i / BITS_MAX_INDEX], i % BITS_MAX_INDEX) {
+            if is_none(bytes[i / BITS_MAX_INDEX], i % BITS_MAX_INDEX) {
                 values.push(Arc::new(DataValue::none(logic_type)));
             } else if let Some(len) = logic_type.raw_len() {
                 /// fixed length (e.g.: int)

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -135,7 +135,7 @@ mod tests {
             Arc::new(ColumnCatalog::new(
                 "c3".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Varchar(Some(2)), false)
+                ColumnDesc::new(LogicalType::Varchar(Some(2)), false, false)
             )),
             Arc::new(ColumnCatalog::new(
                 "c4".to_string(),

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -10,6 +10,7 @@ use integer_encoding::FixedInt;
 use lazy_static::lazy_static;
 
 use ordered_float::OrderedFloat;
+use serde::{Deserialize, Serialize};
 use crate::types::errors::TypeError;
 
 use super::LogicalType;
@@ -25,7 +26,7 @@ pub const DATE_TIME_FMT: &str = "%Y-%m-%d %H:%M:%S";
 
 pub type ValueRef = Arc<DataValue>;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum DataValue {
     Null,
     Boolean(Option<bool>),


### PR DESCRIPTION
### What is changed and how it works?
- support unique field option declaration
- support unique index
  - ddl
    - create table
    - drop table
  - dml
    - insert
    - delete
    - update
  - dql
    - filter
 - added RBO rules:
   - `SimplifyFilter`: 
     - perform constant folding on the conditional expression in the Filter operator
   - `PushPredicateIntoScan`: 
     - filter whether the field matches the index and push down to Scan
- fixed RBO rule:
  - `PushProjectThroughChild`: 
    - fixed the problem of missing fields when pushing down
  -  `PushLimitThroughJoin`
     - fixed the problem that when the on condition in Join generates multiple same number of connection rows, the limit is exceeded
- rename 
  - `Transaction `-> `Iter`
  - `Table ` -> `Transaction`
- TableCodec
  - IndexMeta
  - Index
### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
