### PR TITLE
feat(type): add support for Decimal type in database

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ comfy-table = "7.0.1"
 bytes = "*"
 kip_db = "0.1.2-alpha.15"
 async-recursion = "1.0.5"
+rust_decimal = "1"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -50,7 +50,7 @@ impl<S: Storage> Binder<S> {
                     match &self.bind_expr(expr).await? {
                         ScalarExpression::Constant(value) => {
                             // Check if the value length is too long
-                            value.check_length(columns[i].datatype())?;
+                            value.check_len(columns[i].datatype())?;
                             let cast_value = DataValue::clone(value)
                                 .cast(columns[i].datatype())?;
                             row.push(Arc::new(cast_value))

--- a/src/binder/update.rs
+++ b/src/binder/update.rs
@@ -44,7 +44,7 @@ impl<S: Storage> Binder<S> {
                         bind_table_name.as_ref()
                     ).await? {
                         ScalarExpression::ColumnRef(catalog) => {
-                            value.check_length(catalog.datatype())?;
+                            value.check_len(catalog.datatype())?;
                             columns.push(catalog);
                             row.push(value.clone());
                         },

--- a/src/db.rs
+++ b/src/db.rs
@@ -186,6 +186,9 @@ mod test {
         let _ = kipsql.run("create table t2 (c int primary key, d int unsigned null, e datetime)").await?;
         let _ = kipsql.run("insert into t1 (a, b, k) values (-99, 1, 1), (-1, 2, 2), (5, 2, 2)").await?;
         let _ = kipsql.run("insert into t2 (d, c, e) values (2, 1, '2021-05-20 21:00:00'), (3, 4, '2023-09-10 00:00:00')").await?;
+        let _ = kipsql.run("create table t3 (a int primary key, b decimal(4,2))").await?;
+        let _ = kipsql.run("insert into t3 (a, b) values (1, 1111), (2, 2.01), (3, 3.00)").await?;
+        let _ = kipsql.run("insert into t3 (a, b) values (4, 4444), (5, 5222), (6, 1.00)").await?;
 
         println!("full t1:");
         let tuples_full_fields_t1 = kipsql.run("select * from t1").await?;
@@ -304,6 +307,10 @@ mod test {
         println!("show tables:");
         let tuples_show_tables = kipsql.run("show tables").await?;
         println!("{}", create_table(&tuples_show_tables));
+
+        println!("decimal:");
+        let tuples_decimal = kipsql.run("select * from t3").await?;
+        println!("{}", create_table(&tuples_decimal));
 
         Ok(())
     }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use itertools::Itertools;
 

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -146,6 +146,7 @@ mod tests {
     use std::ops::Bound;
     use std::sync::Arc;
     use itertools::Itertools;
+    use rust_decimal::Decimal;
     use crate::catalog::{ColumnCatalog, ColumnDesc, TableCatalog};
     use crate::storage::table_codec::{COLUMNS_ID_LEN, TableCodec};
     use crate::types::errors::TypeError;
@@ -159,7 +160,12 @@ mod tests {
                 "c1".into(),
                 false,
                 ColumnDesc::new(LogicalType::Integer, true)
-            )
+            ),
+            ColumnCatalog::new(
+                "c2".into(),
+                false,
+                ColumnDesc::new(LogicalType::Decimal(None,None), false)
+            ),
         ];
         let table_catalog = TableCatalog::new(Arc::new("t1".to_string()), columns).unwrap();
         let codec = TableCodec { table: table_catalog.clone() };
@@ -175,6 +181,7 @@ mod tests {
             columns: table_catalog.all_columns(),
             values: vec![
                 Arc::new(DataValue::Int32(Some(0))),
+                Arc::new(DataValue::Decimal(Some(Decimal::new(1, 0)))),
             ]
         };
 

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -46,4 +46,10 @@ pub enum TypeError {
         #[from]
         ParseError,
     ),
+    #[error("try from decimal")]
+    TryFromDecimal(
+        #[source]
+        #[from]
+        rust_decimal::Error,
+    ),
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -79,8 +79,8 @@ impl LogicalType {
             LogicalType::Float => Some(4),
             LogicalType::Double => Some(8),
             /// Note: The non-fixed length type's raw_len is None e.g. Varchar and Decimal
-            LogicalType::Varchar(_)=>None,
-            LogicalType::Decimal(_, _) =>None,
+            LogicalType::Varchar(_) => None,
+            LogicalType::Decimal(_, _) => Some(16),
             LogicalType::Date => Some(4),
             LogicalType::DateTime => Some(8),
         }

--- a/tests/slt/decimal
+++ b/tests/slt/decimal
@@ -1,0 +1,6 @@
+
+statement ok
+CREATE TABLE mytable ( title varchar(256) primary key, cost decimal(4,2));
+
+statement ok
+INSERT INTO mytable (title, cost) VALUES ('A', 1.00);


### PR DESCRIPTION
The database schema has been updated to support the Decimal data type. This includes casting from and to Decimal type in the DataValue structure, creating a new Decimal field in both LogicalType and DataValue structures, and adding appropriate match arms in the from_sqlparser_data_type and can_implicit_cast functions. A new error type for when an attempted conversion from Decimal fails have also been implemented. The round_dp_with_strategy method is used to provide flexibility with scale modification and rounding strategy when casting to Decimal type. Tests for the new functionality have been added as well.

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
