### PR TITLE
fix: add text_files and deleted_text_files to ColumnCatalog

### DIFF
--- a/src/execution/executor/dml/copy_from_file.rs
+++ b/src/execution/executor/dml/copy_from_file.rs
@@ -139,6 +139,8 @@ mod tests {
                 nullable: false,
                 desc: ColumnDesc::new(LogicalType::Integer, true, false),
                 ref_expr: None,
+                text_files: vec![],
+                deleted_text_files: vec![],
             }),
             Arc::new(ColumnCatalog {
                 id: Some(1),
@@ -147,6 +149,8 @@ mod tests {
                 nullable: false,
                 desc: ColumnDesc::new(LogicalType::Float, false, false),
                 ref_expr: None,
+                text_files: vec![],
+                deleted_text_files: vec![],
             }),
             Arc::new(ColumnCatalog {
                 id: Some(1),
@@ -155,6 +159,8 @@ mod tests {
                 nullable: false,
                 desc: ColumnDesc::new(LogicalType::Varchar(Some(10)), false, false),
                 ref_expr: None,
+                text_files: vec![],
+                deleted_text_files: vec![],
             }),
         ];
 


### PR DESCRIPTION
Several fields, 'text_files' and 'deleted_text_files', were added to the ColumnCatalog structure in the 'copy_from_file' module. The addition of these fields will allow the tracking of text files and deleted text files, enhancing error handling and data management.

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
