### PR TITLE
Feat: Add args path for main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ kip_db = "0.1.2-alpha.19"
 rust_decimal = "1"
 csv = "1"
 regex = "1.10.2"
+clap = "4.4.11"
 
 [dev-dependencies]
 cargo-tarpaulin = "0.27.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use std::error::Error;
-use std::io;
-
+use clap::Parser;
 use kip_sql::db::Database;
 use kip_sql::types::tuple::create_table;
+use std::error::Error;
+use std::{env, io};
 
 pub(crate) const BANNER: &str = "
 ██╗  ██╗██╗██████╗ ███████╗ ██████╗ ██╗
@@ -23,22 +23,33 @@ pub const BLOOM: &str = "
               /   \\
 _____________/_ __ \\_____________
 ";
+
+/// KipSQL is a embedded database
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to db file
+    #[arg(short, long, default_value = "./data")]
+    path: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
     println!("{} \nVersion: {}\n", BANNER, env!("CARGO_PKG_VERSION"));
-
     println!(":) Welcome to the KipSQL, Please input sql.\n");
     println!("Tips🔞: ");
     println!("1. input \"quit\" to shutdown");
-    println!("2. all data is in the \'data\' folder in the directory where the application is run");
-
-    server_run().await?;
-
+    println!(
+        "2. all data is in the \'{}\' folder in the directory where the application is run",
+        args.path
+    );
+    server_run(args.path).await?;
     Ok(())
 }
 
-async fn server_run() -> Result<(), Box<dyn Error>> {
-    let db = Database::with_kipdb("./data").await?;
+async fn server_run(path: String) -> Result<(), Box<dyn Error>> {
+    let db = Database::with_kipdb(path).await?;
 
     loop {
         println!("> 👇👇🏻👇🏼👇🏽👇🏾👇🏿 <");


### PR DESCRIPTION
### What problem does this PR solve?
❯ cargo run -- --path '/Users/xwg/dev/rust/KipSQL/data'
<img width="901" alt="CleanShot 2023-12-24 at 00 36 42@2x" src="https://github.com/KipData/kipsql/assets/56066360/2b19f1fb-2c66-495b-9f72-64da25566dfe">
build the SQL layer of KipDB database

Usage: kip-sql [OPTIONS]

Options:
  -p, --path <PATH>  Path to db file [default: ./data]
  -h, --help         Print help
  -V, --version      Print version


### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
